### PR TITLE
Fixed well-formedness error

### DIFF
--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -1968,8 +1968,7 @@ select="$makeDecls"/></xsl:message>
         <xsl:apply-templates mode="justcopy" select="."/>
       </xsl:when>
       <xsl:when test="self::s:rule">
-        <pattern>
-          xmlns="http://www.ascc.net/xml/schematron">
+        <pattern xmlns="http://www.ascc.net/xml/schematron">
           <xsl:attribute name="name">
             <xsl:value-of select="ancestor::tei:constraintSpec/parent::*/@ident"/>
             <xsl:text>-constraint-</xsl:text>


### PR DESCRIPTION
The namespace definition for a schematron <pattern> element came after the <pattern> open tag.  I noticed this when oXygen reported an error when transforming an ODD file into XHTML.
