### PR TITLE
Fixed: Missing quotation mark

### DIFF
--- a/bin/transformtei
+++ b/bin/transformtei
@@ -33,7 +33,7 @@ echo "  --debug              # be verbose, do not delete intermediate files"
 echo "  --apphome=$APPHOME   # where to find app directory"
 echo "  --profiledir=$profiledir    # where to find profile directory"
 echo "  --profile=$profile    # which transformation profile to use"
-echo "  --lang=$lang    # which language to use
+echo "  --lang=$lang    # which language to use "
 echo "  --oxygenlib=$oxygenlib    # where is oxygenlib"
 case $format in
       teitorelaxng) ;;


### PR DESCRIPTION
A quotation mark was missing in transformtei which caused the help to format incorrectly.
