### PR TITLE
find transformtei saxon in Test/lib

### DIFF
--- a/bin/transformtei
+++ b/bin/transformtei
@@ -101,7 +101,7 @@ nocompress=
 schema=
 # ---
 version=`cat $APPHOME/VERSION`
-SAXONJAR=/usr/share/saxon/saxon9he.jar
+SAXONJAR=$APPHOME/Test/lib/saxon9he.jar
 TRANGJAR=$APPHOME/lib/trang.jar
 from=`echo $script | sed 's/to.*//'`
 to=`echo $script | sed 's/.*to//'`


### PR DESCRIPTION
I had trouble running the code, because on Fedora 20 saxon is installed to /usr/share/java/saxon.jar.  This change makes transformtei use the included saxon, which seemed an easy fix to me.
