### PR TITLE
fix percent character in URLs

### DIFF
--- a/latex/latex.xsl
+++ b/latex/latex.xsl
@@ -148,7 +148,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:function name="tei:escapeCharsPartial" as="xs:string" override="yes">
     <xsl:param name="letters"/>
       <xsl:value-of
-	  select="replace($letters,'([#])','\\$1')"/>
+	  select="replace($letters,'([%#])','\\$1')"/>
 
   </xsl:function>
 


### PR DESCRIPTION
Unicode characters are not valid in hyperlink targets.  They lead to broken hyperref output in the LaTeX transform and need to be percent-escaped.  Percent-escaping in XSLT seems difficult, but if they are escaped at the source, this fix makes sure they are escaped in LaTeX correctly.
