### PR TITLE
fix brackets in heading

### DIFF
--- a/latex/latex_core.xsl
+++ b/latex/latex_core.xsl
@@ -220,7 +220,7 @@ of this software, even if advised of the possibility of such damage.
 	       or (ancestor::tei:back and $numberBackHeadings='')
 	       or (not($numberHeadings='true') and ancestor::tei:body)
 	       or (ancestor::tei:front and  $numberFrontHeadings='')">*</xsl:when>
-	       <xsl:otherwise>[<xsl:value-of select="tei:escapeChars(.,.)"/>]</xsl:otherwise>
+	       <xsl:otherwise>[{<xsl:value-of select="tei:escapeChars(.,.)"/>}]</xsl:otherwise>
             </xsl:choose>
 	    <xsl:text>{</xsl:text>
 	    <xsl:apply-templates/>


### PR DESCRIPTION
This wraps section headings in the LaTeX output with {}, so any brackets [] in the heading don't break the syntax.
