### PR TITLE
fix hr milestones in latex output

### DIFF
--- a/latex/latex.xsl
+++ b/latex/latex.xsl
@@ -263,7 +263,7 @@ of this software, even if advised of the possibility of such damage.
     <desc>how to make a horizontal rule</desc>
   </doc>
   <xsl:template name="horizontalRule">
-    <xsl:text>\hline</xsl:text>
+    <xsl:text>\\\rule[0.5ex]{\textwidth}{0.5pt}</xsl:text>
   </xsl:template>
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">


### PR DESCRIPTION
The current hr milestone conversion to \hline does not work for normal text  The result is a LaTeX parser error (Misplaced \noalign), because \hline requires a table context.  This patch changes the implementation to use a horizontally centered hrule, which looks decent.

```
    <tei:milestone rend="hr"/>
```
