### PR TITLE
parametrize the quote environment to use in latex output

### DIFF
--- a/latex/latex_core.xsl
+++ b/latex/latex_core.xsl
@@ -67,7 +67,7 @@ of this software, even if advised of the possibility of such damage.
     <xsl:choose>
       <xsl:when test="@rend='display' or tei:q/tei:p or
 		      tei:quote/tei:l or tei:quote/tei:p">
-        <xsl:text>&#10;\begin{quote}&#10;</xsl:text>
+        <xsl:text>&#10;\begin{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}&#10;</xsl:text>
             <xsl:if test="@n">
               <xsl:text>(</xsl:text>
               <xsl:value-of select="@n"/>
@@ -77,7 +77,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:apply-templates select="*[not(self::tei:bibl)]"/>
 	    <xsl:text>\par&#10;</xsl:text>
             <xsl:apply-templates select="tei:bibl"/>
-        <xsl:text>&#10;\end{quote}&#10;</xsl:text>
+        <xsl:text>&#10;\end{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}&#10;</xsl:text>
       </xsl:when>
       <xsl:otherwise>
 	<xsl:value-of select="$preQuote"/>
@@ -509,9 +509,9 @@ of this software, even if advised of the possibility of such damage.
       display style note</desc>
    </doc>
   <xsl:template name="displayNote">
-    <xsl:text>&#10;\begin{quote}&#10;</xsl:text>
+    <xsl:text>&#10;\begin{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}&#10;</xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>\end{quote}&#10;</xsl:text>
+    <xsl:text>\end{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}&#10;</xsl:text>
   </xsl:template>
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
@@ -645,9 +645,9 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:q|tei:said">
       <xsl:choose>
 	<xsl:when test="not(tei:is-inline(.))">
-	  <xsl:text>&#10;\begin{quote}</xsl:text>
+	  <xsl:text>&#10;\begin{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}</xsl:text>
 	  <xsl:apply-templates/>
-	  <xsl:text>\end{quote}&#10;</xsl:text>
+	  <xsl:text>\end{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}&#10;</xsl:text>
 	</xsl:when>
          <xsl:otherwise>
 	   <xsl:call-template name="makeQuote"/>
@@ -665,10 +665,10 @@ of this software, even if advised of the possibility of such damage.
 	  <xsl:apply-templates/>
 	</xsl:when>
 	<xsl:when test="not(tei:is-inline(.))">
-	  <xsl:text>\begin{quote}</xsl:text>
+	  <xsl:text>\begin{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}</xsl:text>
 	  <xsl:sequence select="tei:makeHyperTarget(@xml:id)"/>
 	  <xsl:apply-templates/>
-	  <xsl:text>\end{quote}</xsl:text>
+	  <xsl:text>\end{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}</xsl:text>
 	</xsl:when>
 	<xsl:otherwise>
 	   <xsl:call-template name="makeQuote"/>
@@ -681,9 +681,9 @@ of this software, even if advised of the possibility of such damage.
       <desc>Process element p with @rend='display'</desc>
    </doc>
   <xsl:template match="tei:p[@rend='display']"> 
-      <xsl:text>&#10;\begin{quote}&#10;</xsl:text>
+      <xsl:text>&#10;\begin{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}&#10;</xsl:text>
       <xsl:apply-templates/>
-      <xsl:text>\end{quote}&#10;</xsl:text>
+      <xsl:text>\end{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}&#10;</xsl:text>
   </xsl:template>
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
@@ -701,9 +701,9 @@ of this software, even if advised of the possibility of such damage.
       <desc>Process element signed</desc>
    </doc>
   <xsl:template match="tei:signed">
-      <xsl:text>&#10;&#10;\begin{quote}&#10;</xsl:text>
+      <xsl:text>&#10;&#10;\begin{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}&#10;</xsl:text>
       <xsl:apply-templates/>
-      <xsl:text>\end{quote}&#10;</xsl:text>
+      <xsl:text>\end{</xsl:text><xsl:value-of select="$quoteEnv"/><xsl:text>}&#10;</xsl:text>
   </xsl:template>
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">

--- a/latex/latex_param.xsl
+++ b/latex/latex_param.xsl
@@ -176,6 +176,11 @@ as a proportion of the page width.</desc>
    </doc>
    <xsl:param name="tableMaxWidth">0.85</xsl:param>
 
+   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="layout" type="string">
+      <desc>Which environment to use for quotes (quote, quotation, quoting, ...)</desc>
+   </doc>
+   <xsl:param name="quoteEnv">quote</xsl:param>
+
    <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="layout" type="boolean">
       <desc>Whether to number lines of poetry</desc>
    </doc>


### PR DESCRIPTION
The LaTeX quote environment is very limited (as is the quotation environment), and I needed to use the quoting package to avoid horizontal white space in a line-by-line transcription.  The quoting package is the most flexible, so using it unconditionally may be an option, but then its parameters need to be configurable, and also its auto-detection is currently not compatible with the generated output (it seems to use whitespace instead of not \par, etc).  I don't know much about the whole topic to even try a fancy solution, so I offer this easy parametrization for a first step.  The whole quote-business seems to be somewhat messy, and LaTeX quote environments are currently overloaded for different use cases.  Oh well!
