### PR TITLE
fix underline in latex output

### DIFF
--- a/latex/latex_core.xsl
+++ b/latex/latex_core.xsl
@@ -286,7 +286,6 @@ of this software, even if advised of the possibility of such damage.
 	</xsl:for-each>
       </xsl:variable>
       <xsl:variable name="cmd">
-	<xsl:if test="tei:render-underline(.)">\uline </xsl:if>
 	<xsl:if test="tei:render-strike(.)">\sout </xsl:if>
 	<xsl:for-each select="tokenize(normalize-space(@rend),' ')">
          <xsl:choose>
@@ -300,6 +299,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:when test=".='quoted'">\textquoted </xsl:when>
             <xsl:when test=".='sub'">\textsubscript </xsl:when>
             <xsl:when test=".='subscript'">\textsubscript </xsl:when>
+            <xsl:when test=".='underline'">\uline </xsl:when>
             <xsl:when test=".='sup'">\textsuperscript </xsl:when>
             <xsl:when test=".='superscript'">\textsuperscript </xsl:when>
             <xsl:when test=".='underwavyline'">\uwave </xsl:when>


### PR DESCRIPTION
I don't know why underline gets a special treatment in the latex generator, but I found it to be buggy.  Here is an example input/output:

```
    <tei:p><tei:hi rend="underline">Den 5.<tei:hi rend="sup">ten</tei:hi> Januar. 1716.</tei:hi></tei:p>

    \uline{Den 5.\uline{\textsuperscript{ten}} Januar. 1716.}
```

As you can see, the underline occurs a second time in front of the sup, and this actually is rendered by a double underline, which is not intended.  The patch makes unederline like any other inline highlighter, which works for me.
