### PR TITLE
put left margin notes in the reverse margin in LaTeX output

### DIFF
--- a/latex/latex_core.xsl
+++ b/latex/latex_core.xsl
@@ -498,6 +498,17 @@ of this software, even if advised of the possibility of such damage.
       pointing to margin</desc>
    </doc>
   <xsl:template name="marginalNote">
+    <xsl:choose>
+      <xsl:when test="@place='left' or
+		      @place='marginLeft' or
+		      @place='margin-left' or
+		      @place='margin_left'">
+	\reversemarginpar
+      </xsl:when>
+      <xsl:otherwise>
+	\normalmarginpar
+      </xsl:otherwise>
+    </xsl:choose>
     <xsl:text>\marginnote{</xsl:text>
     <xsl:sequence select="tei:makeHyperTarget(@xml:id)"/>
     <xsl:apply-templates/>


### PR DESCRIPTION
This change puts left margin notes in the reverse margin.  Well, LaTeX has the concept of inner and outer margins, while common/common_core.xsl seems to focus on left and right.  But anyway, this change is an improvement over the status quo (I think), and it does the right thing in one-sided layouts at least (also, in a side-by-side edition where picture is left and text is right).
