### PR TITLE
add pagebreakstyles plain and sidebyside to LaTeX output

### DIFF
--- a/latex/latex_core.xsl
+++ b/latex/latex_core.xsl
@@ -632,6 +632,21 @@ of this software, even if advised of the possibility of such damage.
             <xsl:value-of select="@n"/>
             <xsl:text>]</xsl:text>
          </xsl:when>
+         <xsl:when test="$pagebreakStyle='plain'">
+	     <xsl:text>\vspace{1ex}&#10;\par&#10;</xsl:text>
+             <xsl:value-of select="@n"/>
+	     <xsl:text>\vspace{1ex}&#10;</xsl:text>
+         </xsl:when>
+         <xsl:when test="$pagebreakStyle='sidebyside'">
+	     <xsl:text>\cleartoleftpage&#10;</xsl:text>
+	     \begin{figure}[ht!]\makebox[\textwidth][c]{
+	     <xsl:text>\includegraphics[width=\textwidth]{</xsl:text><xsl:value-of select="tei:resolveURI(.,@facs)"/><xsl:text>}</xsl:text>
+	     }\end{figure}
+	     <xsl:text>\cleardoublepage&#10;</xsl:text>
+	     <xsl:text>\vspace{1ex}&#10;\par&#10;</xsl:text>
+             <xsl:value-of select="@n"/>
+	     <xsl:text>\vspace{1ex}&#10;</xsl:text>
+	 </xsl:when>
 	 <xsl:when test="@facs">
 	   <xsl:value-of select="concat('% image:', tei:resolveURI(.,@facs),'&#10;')"/>
 	 </xsl:when>

--- a/latex/latex_param.xsl
+++ b/latex/latex_param.xsl
@@ -564,6 +564,19 @@ characters. The normal characters remain active for LaTeX commands.
    <xsl:template name="latexBegin">
       <xsl:text>
 \makeatletter
+\newcommand*{\cleartoleftpage}{%
+  \clearpage
+    \if@twoside
+    \ifodd\c@page
+      \hbox{}\newpage
+      \if@twocolumn
+        \hbox{}\newpage
+      \fi
+    \fi
+  \fi
+}
+\makeatother
+\makeatletter
 \thispagestyle{empty}
 \markright{\@title}\markboth{\@title}{\@author}
 \renewcommand\small{\@setfontsize\small{9pt}{11pt}\abovedisplayskip 8.5\p@ plus3\p@ minus4\p@


### PR DESCRIPTION
Here are two new pagebreakstyles that I found useful: "plain" is for page labels that already are sufficiently marked up (for example, already have [] around them).  "sidebyside" is the same but also expects a facs attribute with an image of the page.  The result here is similar to a critical edition, with the image on the even (left) pages, and the page label + following content on the odd (right) pages.

Now, ideally, placing the @facs images and styling the page label would be separate templates.  But that's more than I needed, so here is a first step towards fancier pagebreakstyles.

I guess another solution for me would be to overwrite the whole pb template in the profile.  But a "critical edition" layout seems generally useful, so maybe you like to include it.
