### PR TITLE
make hypersetup in LaTeX output configurable

### DIFF
--- a/latex/latex_param.xsl
+++ b/latex/latex_param.xsl
@@ -198,6 +198,11 @@ this must be the name of a TEI element</desc>
    <xsl:param name="latexGeometryOptions">twoside,lmargin=1in,rmargin=1in,tmargin=1in,bmargin=1in,marginparwidth=0.75in</xsl:param>
 
    <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="userpackage" type="string">
+      <desc>Configuration to pass to hypersetup.</desc>
+   </doc>
+   <xsl:param name="hyperSetup">linkbordercolor=0.75 0.75 0.75,urlbordercolor=0.75 0.75 0.75,bookmarksnumbered=true</xsl:param>
+
+   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="userpackage" type="string">
       <desc>Depth of nesting of reference documentation when processing ODD</desc>
    </doc>
    <xsl:param name="specLinkDepth">2</xsl:param>
@@ -587,7 +592,7 @@ characters. The normal characters remain active for LaTeX commands.
 \fancyfoot[LE]{}
 \fancyfoot[CE]{\thepage}
 \fancyfoot[RE]{\TheID}
-\hypersetup{linkbordercolor=0.75 0.75 0.75,urlbordercolor=0.75 0.75 0.75,bookmarksnumbered=true}
+\hypersetup{</xsl:text><xsl:value-of select="$hyperSetup"/><xsl:text>}
 \fancypagestyle{plain}{\fancyhead{}\renewcommand{\headrulewidth}{0pt}}</xsl:text>
    </xsl:template>
 


### PR DESCRIPTION
A simple patch to make hypersetup settings configurable.  I like me some blue links without the boxes :)
