### PR TITLE
make margin font in LaTeX output configurable

### DIFF
--- a/latex/latex_param.xsl
+++ b/latex/latex_param.xsl
@@ -125,10 +125,12 @@ the beginning of the document</desc>
 \usepackage[normalem]{ulem}
 \usepackage{fancyvrb}
 \usepackage{fancyhdr}
-\usepackage{marginnote}
-\renewcommand*{\marginfont}{\itshape\footnotesize}
 \usepackage{graphicx}
+\usepackage{marginnote}
 </xsl:text>
+<xsl:if test="not($marginFont='')">
+\renewcommand*{\marginfont}{<xsl:value-of select="$marginFont"/>}
+</xsl:if>
 <xsl:if test="key('TREES',1)">
   \usepackage{pstricks,pst-node,pst-tree}
 </xsl:if>
@@ -374,6 +376,8 @@ characters. The normal characters remain active for LaTeX commands.
 <xsl:param name="gothicFont">Lucida Blackletter</xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for calligraphic</desc>   </doc>
 <xsl:param name="calligraphicFont">Lucida Calligraphy</xsl:param>
+<doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Command to set margin font</desc>   </doc>
+<xsl:param name="marginFont">\itshape\footnotesize</xsl:param>
   <xsl:param name="longtables">true</xsl:param>
 
    <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="layout">


### PR DESCRIPTION
I needed to disable the special marginfont in the latex output, so I added this configuration parameter that allows to use the empty string to use the LaTeX default.
