### PR TITLE
fix newline in center env in LaTeX output

### DIFF
--- a/latex/latex_core.xsl
+++ b/latex/latex_core.xsl
@@ -377,7 +377,7 @@ of this software, even if advised of the possibility of such damage.
       <desc>line break</desc>
    </doc>
    <xsl:template name="lineBreak">
-      <xsl:text>{\hskip1pt}\newline </xsl:text>
+      <xsl:text>{\hskip1pt}\\ </xsl:text>
   </xsl:template>
    <xsl:template name="lineBreakAsPara"> 
       <xsl:text>\par  </xsl:text>


### PR DESCRIPTION
\newline is not valid in centering environments, and some other places.  The \ macro is more versatile, as it adapts to its environment.
