### PR TITLE
allow lb in div elements

### DIFF
--- a/common/common_core.xsl
+++ b/common/common_core.xsl
@@ -1207,7 +1207,6 @@ of this software, even if advised of the possibility of such damage.
 
   <xsl:template match="tei:lb">
     <xsl:choose>
-      <xsl:when test="parent::tei:div"/>
       <xsl:when test="@type='hyphenInWord' and @rend='hidden'"/>
       <xsl:when test="@rend='hidden'">
         <xsl:text> </xsl:text>


### PR DESCRIPTION
I had lb in div elements in TEI (as we used div instead of p elements for separating content).  These were deleted by common/common_core.xsl.  This patch restores lb in div elements, and allows the individual format handlers to deal with them.  For LaTeX, this did what I wanted.

I guess there must have been a reason to delete them, but I can't imagine one.  If there is an issue with this,  maybe this calls for a configuration option?
