### PR TITLE
Fixed: Spaces in paths

### DIFF
--- a/bin/transformtei
+++ b/bin/transformtei
@@ -174,7 +174,7 @@ else
   SDIR=`(cd $REALD; pwd)`
   REALSOURCE=$SDIR/`basename $TEISOURCE`
   echo using $REALSOURCE as default source
-  localsource=' -DdefaultSource="$REALSOURCE" '
+  localsource=" -DdefaultSource=\"$REALSOURCE\" "
 fi
 
 in=${1:?"no input file supplied; for usage syntax $0 --help"}


### PR DESCRIPTION
Previously, using single-quotes would result in a nearly-empty output schema.

This commit fixes this issue by using escaped double-quotes. This fix has been tested on paths with and without spaces.

Fixes #53.
