### PR TITLE
Fix tei:isInline() return 'false' on (parent:: | self::)(tei:front | tei:body | tei:back)

### DIFF
--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -329,6 +329,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:when test="parent::tei:div">false</xsl:when>
             <xsl:when test="parent::tei:titlePage">false</xsl:when>
             <xsl:when test="parent::tei:body">false</xsl:when>
+            <xsl:when test="parent::tei:front">false</xsl:when>
             <xsl:when test="not(self::*)">true</xsl:when>
             <xsl:when test="parent::tei:bibl/parent::tei:q">true</xsl:when>
             <xsl:when test="tei:match(@rend,'inline') and not(tei:p or tei:l)">true</xsl:when>

--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -330,6 +330,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:when test="parent::tei:titlePage">false</xsl:when>
             <xsl:when test="parent::tei:body">false</xsl:when>
             <xsl:when test="parent::tei:front">false</xsl:when>
+            <xsl:when test="parent::tei:back">false</xsl:when>
             <xsl:when test="not(self::*)">true</xsl:when>
             <xsl:when test="parent::tei:bibl/parent::tei:q">true</xsl:when>
             <xsl:when test="tei:match(@rend,'inline') and not(tei:p or tei:l)">true</xsl:when>

--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -331,6 +331,9 @@ of this software, even if advised of the possibility of such damage.
             <xsl:when test="parent::tei:body">false</xsl:when>
             <xsl:when test="parent::tei:front">false</xsl:when>
             <xsl:when test="parent::tei:back">false</xsl:when>
+            <xsl:when test="self::tei:body">false</xsl:when>
+            <xsl:when test="self::tei:front">false</xsl:when>
+            <xsl:when test="self::tei:back">false</xsl:when>
             <xsl:when test="not(self::*)">true</xsl:when>
             <xsl:when test="parent::tei:bibl/parent::tei:q">true</xsl:when>
             <xsl:when test="tei:match(@rend,'inline') and not(tei:p or tei:l)">true</xsl:when>


### PR DESCRIPTION
I encountered a problem with tei:pb when transforming to XML-FO. When tei:pb is direct child of tei:front, tei:body, or tei:back it was outputted as fo:inline. This rendered the XML-FO invalid, as fo:inline may not be direct child of fo:flow.
The function tei:isInline() is called with the parent node of tei:pb as parameter (tei:front | tei:body | tei:back in the described cases). Adding xsl:when for self::(tei:front | tei:body | tei:back) fixed the issue.

Moreover as tei:pb should be handled equally in tei:front, tei:body, tei:back xsl:when statements were added for parent::(tei:front | tei:back).