### PR TITLE
fix FO footnoteSize and footnotenumSize

### DIFF
--- a/fo/fo_param.xsl
+++ b/fo/fo_param.xsl
@@ -409,12 +409,14 @@ there are no bookmarks or other such features. Possible values are
    </doc>
   <xsl:param name="footnoteSize">
       <xsl:value-of select="$bodyMaster * 0.9"/>
+      <xsl:text>pt</xsl:text>
   </xsl:param>
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string">
       <desc>Font size for footnote numbers</desc>
    </doc>
   <xsl:param name="footnotenumSize">
     <xsl:value-of select="$bodyMaster * 0.7"/>
+    <xsl:text>pt</xsl:text>
   </xsl:param>
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string">
       <desc>Colour for display of element names</desc>


### PR DESCRIPTION
was undone by a previous faulty merge, sorry

I checked the previous merges and realised, that when I had unintentionally merged the initial pull-request to one of my other pull-requests and undone it, it wasn't a reset but a revert, sorry for the confusion...

Merging this will fix it -)