### PR TITLE
add parameters for front, body, back line-height

### DIFF
--- a/fo/fo_core.xsl
+++ b/fo/fo_core.xsl
@@ -585,6 +585,21 @@ of this software, even if advised of the possibility of such damage.
 
   <xsl:template match="tei:p">
       <block>
+         <xsl:if test="not(parent::tei:note)">
+            <xsl:attribute name="line-height">
+               <xsl:choose>
+                  <xsl:when test="ancestor::tei:front">
+                     <xsl:value-of select="$lineheightFrontpage"/>
+                  </xsl:when>
+                  <xsl:when test="ancestor::tei:body">
+                     <xsl:value-of select="$lineheightBodypage"/>
+                  </xsl:when>
+                  <xsl:when test="ancestor::tei:back">
+                     <xsl:value-of select="$lineheightBackpage"/>
+                  </xsl:when>
+               </xsl:choose>
+            </xsl:attribute>
+         </xsl:if>
          <xsl:if test="preceding-sibling::tei:p">
             <xsl:attribute name="text-indent">
                <xsl:value-of select="$parIndent"/>

--- a/fo/fo_param.xsl
+++ b/fo/fo_param.xsl
@@ -183,6 +183,23 @@ of this software, even if advised of the possibility of such damage.
 </desc>
    </doc>
   <xsl:param name="formatFrontpage">i</xsl:param>
+  
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="layout" type="string">
+    <desc>Set line-height for back matter
+    </desc>
+  </doc>
+  <xsl:param name="lineheightBackpage">1</xsl:param>
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="layout" type="string">
+    <desc>Set line-height for main matter
+    </desc>
+  </doc>
+  <xsl:param name="lineheightBodypage">1</xsl:param>
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="layout" type="string">
+    <desc>Set line-height for front matter
+    </desc>
+  </doc>
+  <xsl:param name="lineheightFrontpage">1</xsl:param>
+  
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="layout" type="boolean">
       <desc>Put front matter in multiple columns</desc>
    </doc>


### PR DESCRIPTION
as discussion in #73 tended towards an inclusive rather than an exclusive approach,at the moment, this feature will only be applied to tei:p[not(parent::tei:note)]