### PR TITLE
add paramete for FO lineheight application rules

### DIFF
--- a/fo/fo_core.xsl
+++ b/fo/fo_core.xsl
@@ -561,6 +561,24 @@ of this software, even if advised of the possibility of such damage.
             <block end-indent="0pt" start-indent="0pt" text-align="start" font-style="normal"
                    text-indent="{$parIndent}"
                    font-size="{$footnoteSize}">
+              <xsl:attribute name="line-height">
+                <xsl:choose>
+                  <xsl:when test="$lineheightApplicationRules = ('footnote', 'all')">
+                    <xsl:choose>
+                      <xsl:when test="ancestor::tei:front">
+                        <xsl:value-of select="$lineheightFrontpage"/>
+                      </xsl:when>
+                      <xsl:when test="ancestor::tei:body">
+                        <xsl:value-of select="$lineheightBodypage"/>
+                      </xsl:when>
+                      <xsl:when test="ancestor::tei:back">
+                        <xsl:value-of select="$lineheightBackpage"/>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:when>
+                  <xsl:otherwise>normal</xsl:otherwise>
+                </xsl:choose>
+              </xsl:attribute>
               <xsl:if test="@xml:id">
                   <xsl:attribute name="id">
                      <xsl:value-of select="@xml:id"/>
@@ -668,6 +686,24 @@ of this software, even if advised of the possibility of such damage.
              font-size="{$quoteSize}"
              space-before.optimum="{$exampleBefore}"
              space-after.optimum="{$exampleAfter}">
+        <xsl:attribute name="line-height">
+          <xsl:choose>
+            <xsl:when test="$lineheightApplicationRules = ('block-quote', 'all')and (not(parent::tei:note) or $lineheightApplicationRules = 'note')">
+              <xsl:choose>
+                <xsl:when test="ancestor::tei:front">
+                  <xsl:value-of select="$lineheightFrontpage"/>
+                </xsl:when>
+                <xsl:when test="ancestor::tei:body">
+                  <xsl:value-of select="$lineheightBodypage"/>
+                </xsl:when>
+                <xsl:when test="ancestor::tei:back">
+                  <xsl:value-of select="$lineheightBackpage"/>
+                </xsl:when>
+              </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>normal</xsl:otherwise>
+          </xsl:choose>
+        </xsl:attribute>
 	<xsl:if test="@xml:id">
 	  <xsl:attribute name="id">
 	    <xsl:value-of select="@xml:id"/>

--- a/fo/fo_param.xsl
+++ b/fo/fo_param.xsl
@@ -188,6 +188,18 @@ of this software, even if advised of the possibility of such damage.
     <desc>Set line-height for back matter
     </desc>
   </doc>
+  <xsl:param name="lineheightApplicationRules" select="('p')"></xsl:param>
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="layout" type="string">
+    <desc>
+      Sequence of identifiers for lineheight application (has to be evaluated as XPath). Add the following values to the sequence in order to:
+      <ul>
+        <li>'p' : apply lineheight to tei:p elements, excluding those in tei:note, and in tei:quote elements returning false from tei:isInline.</li>
+        <li>'footnote' :  in addition to 'p' apply lineheight to all tei:note elements with @place ='foot'</li>
+        <li>'block-quote' : in addition to 'p' apply lineheight to block quotes</li>
+        <li>'all' : apply lineheight parameters respectively to the whole page sequences</li>
+      </ul>
+    </desc>
+  </doc>
   <xsl:param name="lineheightBackpage">1</xsl:param>
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="layout" type="string">
     <desc>Set line-height for main matter

--- a/fo/fo_textstructure.xsl
+++ b/fo/fo_textstructure.xsl
@@ -97,6 +97,9 @@ of this software, even if advised of the possibility of such damage.
          <xsl:otherwise>
             <page-sequence format="{$formatBackpage}" text-align="{$alignment}" hyphenate="{$hyphenate}"
                            language="{$language}">
+              <xsl:if test="$lineheightApplicationRules = 'all'">
+                <xsl:attribute name="line-height" select="$lineheightBackpage"/>
+              </xsl:if>
                <xsl:call-template name="choosePageMaster">
                   <xsl:with-param name="where">
                      <xsl:value-of select="$backMulticolumns"/>
@@ -143,8 +146,11 @@ of this software, even if advised of the possibility of such damage.
        <xsl:otherwise>
 	 <!-- start page sequence -->
 	 <page-sequence format="{$formatBodypage}" text-align="{$alignment}" hyphenate="{$hyphenate}"
-			language="{$language}"
-			initial-page-number="1">
+	         language="{$language}"
+	         initial-page-number="1">
+	   <xsl:if test="$lineheightApplicationRules = 'all'">
+	     <xsl:attribute name="line-height" select="$lineheightBodypage"/>
+	   </xsl:if>
 	   <xsl:call-template name="choosePageMaster">
 	     <xsl:with-param name="where">
 	       <xsl:value-of select="$bodyMulticolumns"/>
@@ -356,6 +362,9 @@ of this software, even if advised of the possibility of such damage.
 	     <page-sequence format="{$formatFrontpage}" force-page-count="end-on-even"
 			    hyphenate="{$hyphenate}"
 			    language="{$language}">
+	       <xsl:if test="$lineheightApplicationRules = 'all'">
+	         <xsl:attribute name="line-height" select="$lineheightBackpage"/>
+	       </xsl:if>
 	       <xsl:call-template name="choosePageMaster">
 		 <xsl:with-param name="where">
 		   <xsl:value-of select="$frontMulticolumns"/>


### PR DESCRIPTION
added a parameter that allows different configuration options for line-height application on tei:p, footnotes, and blockquote

closes #82