### PR TITLE
added param for currentDir and added slash as separator

### DIFF
--- a/common/teianttasks.xml
+++ b/common/teianttasks.xml
@@ -387,6 +387,7 @@
         <param name="defaultSource" expression="${defaultSource}" if="defaultSource"/>
         <param name="selectedSchema" expression="${selectedSchema}" if="selectedSchema"/>
         <param name="verbose" expression="${verbose}" if="verbose"/>
+        <param name="currentDirectory" expression="${inputDir}"/>
       </xslt>
     </sequential>
   </macrodef>

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -214,8 +214,7 @@ of this software, even if advised of the possibility of such damage.
 	  <xsl:text>/xml/tei/odd/p5subset.xml</xsl:text>
 	</xsl:when>
 	<xsl:otherwise>
-	  <xsl:value-of select="$currentDirectory"/>
-	  <xsl:value-of select="$loc"/>
+	  <xsl:value-of select="string-join(($currentDirectory, $loc), '/')"/>
 	</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>


### PR DESCRIPTION
I was having trouble with relative filenames given as @source on `<schemaSpec>` when trying to generate a RelaxNG schema from an ODD. ODD processing failed in odd2odd.xsl with the error 'Source … not readable'. (Absolute paths did work though)
It turned out, the param `currentDir` wasn't set at all so I added it to the ANT macro def. 

I didn't investigate, though, if that fix could apply to other transformations, as well?!