### PR TITLE
Trim leading whitespace in instrText, which may or may not be present.

### DIFF
--- a/docx/from/functions.xsl
+++ b/docx/from/functions.xsl
@@ -223,19 +223,22 @@ of this software, even if advised of the possibility of such damage.
 
   <xsl:function name="tei:processInstruction"  as="xs:string">
     <xsl:param name="instr"/>
+    <xsl:variable name="instr">
+      <xsl:value-of select="replace($instr, '^\s+|\s+$', '')"></xsl:value-of>
+    </xsl:variable>
     <xsl:choose>
       <xsl:when test="matches($instr,'REF _')"> <!-- this will also catch NOTEREF _ -->
 	  <xsl:value-of select="concat('#',substring-before(substring-after($instr,'_'),'&#32;'))"/>
       </xsl:when>
-      <xsl:when test="matches($instr,' HYPERLINK \\l ')">
+      <xsl:when test="matches($instr,'HYPERLINK \\l ')">
 	<xsl:variable name="target">
-	  <xsl:value-of   select="translate(tokenize($instr,' ')[4],$dq,'')"/>
+	  <xsl:value-of   select="translate(tokenize($instr,' ')[3],$dq,'')"/>
 	</xsl:variable>
 	<xsl:value-of select="if (matches($target,'^_')) then  concat('#',substring($target,2)) else $target"/>
       </xsl:when>
-      <xsl:when test="matches($instr,' HYPERLINK')">
+      <xsl:when test="matches($instr,'HYPERLINK')">
 	<xsl:variable name="target">
-	  <xsl:value-of   select="translate(tokenize($instr,' ')[2],$dq,'')"/>
+	  <xsl:value-of   select="translate(tokenize($instr,' ')[1],$dq,'')"/>
 	</xsl:variable>
 	<xsl:value-of select="if (matches($target,'^_')) then  concat('#',substring($target,2)) else $target"/>
       </xsl:when>


### PR DESCRIPTION
So my Word document has this element:

```
      <w:r w:rsidR="00E86F6B">
        <w:instrText>HYPERLINK \l "_ENREF_18" \o "Temporary, 2003 #8947"</w:instrText>
      </w:r>
```

Which means that the current method of checking only for " HYPERLINK" fails, and produces several hyperlinks in the end, as each space separated entry gets converted into a separate link. The example above will result in something like (after Docx to TEI to XHTML):

```
[<a class="link_ref" href="HYPERLINK">18</a>, <a class="link_ref" href="\l">18</a>, <a class="link_ref" href="&#34;_ENREF_18&#34;">18</a>, <a class="link_ref" href="\o">18</a>, <a class="link_ref" href="&#34;Temporary,">18</a>, <a class="link_ref" href="2003">18</a>, and 18]
```

I've tried to find a reference in the standard that a leading space in `instrText` is mandatory, but it seems like it can either be there or not. Happy to be educated on that. Point remains, that my document has an `instrText` with a `HYPERLINK` without a leading space.

So when we fall back to `processInstruction`, perhaps there's no real harm in stripping the leading space, if it exists? The tokenization changes too, but other things remain the same.

 Let me know what you think.

 