### PR TITLE
Add text from the node, in addition to the processed bibliography instruction.

### DIFF
--- a/docx/from/pass2.xsl
+++ b/docx/from/pass2.xsl
@@ -565,6 +565,7 @@ of this software, even if advised of the possibility of such damage.
 	<xsl:processing-instruction name="biblio">
 	  <xsl:value-of select="$target"/>
 	</xsl:processing-instruction>
+	<xsl:value-of select="./text()"/>
       </xsl:when>
       <xsl:when test="matches(@target,'^LINK Excel.Sheet.')">
 	<xsl:sequence select="tei:docxError('cannot embed Excel  spreadsheet')"/>

--- a/docx/from/pass2.xsl
+++ b/docx/from/pass2.xsl
@@ -565,7 +565,17 @@ of this software, even if advised of the possibility of such damage.
 	<xsl:processing-instruction name="biblio">
 	  <xsl:value-of select="$target"/>
 	</xsl:processing-instruction>
-	<xsl:value-of select="./text()"/>
+        <xsl:choose>
+          <xsl:when test="count(text()) &lt; 2">
+            <xsl:value-of select="text()"/>
+            <xsl:apply-templates select="tei:ref" mode="pass2"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="text()[1]"/>
+            <xsl:apply-templates select="tei:ref" mode="pass2"/>
+            <xsl:value-of select="remove(text(), 1)"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:when>
       <xsl:when test="matches(@target,'^LINK Excel.Sheet.')">
 	<xsl:sequence select="tei:docxError('cannot embed Excel  spreadsheet')"/>


### PR DESCRIPTION
I have a Docx document like this:

```
<w:r w:rsidR="00A134F5">
    <w:rPr>
        <w:rFonts w:ascii="Times New Roman" w:hAnsi="Times New Roman" w:cs="Times New Roman"/>
    </w:rPr>
    <w:fldChar w:fldCharType="begin"/>
</w:r>
<w:r w:rsidR="0003278C">
    <w:rPr>
        <w:rFonts w:ascii="Times New Roman" w:hAnsi="Times New Roman" w:cs="Times New Roman"/>
    </w:rPr>
    <w:instrText xml:space="preserve"> ADDIN EN.CITE &lt;EndNote&gt;&lt;Cite&gt;&lt;Author&gt;Heisman&lt;/Author&gt;&lt;Year&gt;2011&lt;/Year&gt;&lt;RecNum&gt;8054&lt;/RecNum&gt;&lt;DisplayText&gt;[1]&lt;/DisplayText&gt;&lt;record&gt;&lt;rec-number&gt;8054&lt;/rec-number&gt;&lt;foreign-keys&gt;&lt;key app="EN" db-id="f5zt9sprdvpxwpezx21xf0zzevfetw0weprs"&gt;8054&lt;/key&gt;&lt;/foreign-keys&gt;&lt;ref-type name="Book"&gt;6&lt;/ref-type&gt;&lt;contributors&gt;&lt;authors&gt;&lt;author&gt;Heisman, J.&lt;/author&gt;&lt;/secondary-authors&gt;&lt;/contributors&gt;&lt;titles&gt;&lt;title&gt;&lt;style face="normal" font="default" size="100%"&gt;: This is a book chapter title.&lt;/style&gt;&lt;/title&gt;&lt;/titles&gt;&lt;dates&gt;&lt;year&gt;2011&lt;/year&gt;&lt;/dates&gt;&lt;pub-location&gt;Washington, D. C.&lt;/pub-location&gt;&lt;publisher&gt;ASM Press&lt;/publisher&gt;&lt;urls&gt;&lt;/urls&gt;&lt;/record&gt;&lt;/Cite&gt;&lt;/EndNote&gt;</w:instrText>
</w:r>
<w:r w:rsidR="00A134F5">
    <w:rPr>
        <w:rFonts w:ascii="Times New Roman" w:hAnsi="Times New Roman" w:cs="Times New Roman"/>
    </w:rPr>
    <w:fldChar w:fldCharType="separate"/>
</w:r>
<w:r w:rsidR="0003278C">
    <w:rPr>
        <w:rFonts w:ascii="Times New Roman" w:hAnsi="Times New Roman" w:cs="Times New Roman"/>
        <w:noProof/>
    </w:rPr>
    <w:t>[</w:t>
</w:r>
<w:r w:rsidR="00A134F5">
    <w:fldChar w:fldCharType="begin"/>
</w:r>
<w:r w:rsidR="00E86F6B">
    <w:instrText>HYPERLINK \l "_ENREF_1" \o "Heisman, 2011 #8054"</w:instrText>
</w:r>
<w:r w:rsidR="00A134F5">
    <w:fldChar w:fldCharType="separate"/>
</w:r>
<w:r w:rsidR="001A07BF">
    <w:rPr>
        <w:rFonts w:ascii="Times New Roman" w:hAnsi="Times New Roman" w:cs="Times New Roman"/>
        <w:noProof/>
    </w:rPr>
    <w:t>1</w:t>
</w:r>
<w:r w:rsidR="00A134F5">
    <w:fldChar w:fldCharType="end"/>
</w:r>
<w:r w:rsidR="0003278C">
    <w:rPr>
        <w:rFonts w:ascii="Times New Roman" w:hAnsi="Times New Roman" w:cs="Times New Roman"/>
        <w:noProof/>
    </w:rPr>
    <w:t>]</w:t>
</w:r>

```

Which looks like "[1]" in Word. Converted to HTML, the opening square bracket gets lost in the conversion. This is because a separate `ref` gets created for each of those fldChar sections (between `begin` and `separate` and `end`:

```
<ref target=" ADDIN EN.CITE &lt;EndNote&gt;&lt;Cite&gt;&lt;Author&gt;Heisman&lt;/Author&gt;&lt;Year&gt;2011&lt;/Year&gt;&lt;RecNum&gt;8054&lt;/RecNum&gt;&lt;DisplayText&gt;[1]&lt;/DisplayText&gt;&lt;record&gt;&lt;rec-number&gt;8054&lt;/rec-number&gt;&lt;foreign-keys&gt;&lt;key app="EN" db-id="f5zt9sprdvpxwpezx21xf0zzevfetw0weprs"&gt;8054&lt;/key&gt;&lt;/foreign-keys&gt;&lt;ref-type name="Book"&gt;6&lt;/ref-type&gt;&lt;contributors&gt;&lt;authors&gt;&lt;author&gt;Heisman, J.&lt;/author&gt;&lt;/secondary-authors&gt;&lt;/contributors&gt;&lt;titles&gt;&lt;title&gt;&lt;style face="normal" font="default" size="100%"&gt;: This is a book chapter title.&lt;/style&gt;&lt;/title&gt;&lt;/titles&gt;&lt;dates&gt;&lt;year&gt;2011&lt;/year&gt;&lt;/dates&gt;&lt;pub-location&gt;Washington, D. C.&lt;/pub-location&gt;&lt;publisher&gt;ASM Press&lt;/publisher&gt;&lt;urls&gt;&lt;/urls&gt;&lt;/record&gt;&lt;/Cite&gt;&lt;/EndNote&gt;">[</ref>
<ref target="HYPERLINK \l &#34;_ENREF_1&#34; \o &#34;Heisman, 2011 #8054&#34;">1</ref>].
```

And when these `ref` elements get processed in `pass2`, only the `target` attribute gets processed further and the text information is discarded:

```
<xsl:when test="tei:biblioInstruction($target)">
  <xsl:processing-instruction name="biblio">
    <xsl:value-of select="$target"/>
  </xsl:processing-instruction>
</xsl:when>
```

This results in the final HTML looking like (note the missing opening square bracket): 
```
<p><span style="font-style:italic">Cryptococcus neoformans</span> is a globally distributed basidiomycetous human fungal pathogen that causes life threatening meningoencephalitis 1].
```

I'm not sure what the correct way to address this issue is, but copying the text value fixes the problem for me, at least in this context. Any ideas?