### PR TITLE
Addressing problem with localsource when compiling odds

### DIFF
--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -217,6 +217,9 @@ of this software, even if advised of the possibility of such damage.
 	<xsl:when test="$currentDirectory=''">
 	  <xsl:value-of select="resolve-uri($loc,base-uri($top))"/>
 	</xsl:when>
+        <xsl:when test="$loc = $DEFAULTSOURCE">
+          <xsl:value-of select="resolve-uri($loc)"/>
+	</xsl:when>
 	<xsl:otherwise>
 	  <xsl:value-of select="resolve-uri(string-join(($currentDirectory, $loc), '/'),base-uri($top))"/>
 	</xsl:otherwise>

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -217,8 +217,8 @@ of this software, even if advised of the possibility of such damage.
 	<xsl:when test="$currentDirectory=''">
 	  <xsl:value-of select="resolve-uri($loc,base-uri($top))"/>
 	</xsl:when>
-        <xsl:when test="$loc = $DEFAULTSOURCE">
-          <xsl:value-of select="resolve-uri($loc)"/>
+  <xsl:when test="starts-with($loc,'/')">
+      <xsl:value-of select="resolve-uri($loc)"/>
 	</xsl:when>
 	<xsl:otherwise>
 	  <xsl:value-of select="resolve-uri(string-join(($currentDirectory, $loc), '/'),base-uri($top))"/>


### PR DESCRIPTION
The localsource parameter was wrongly being prepended with the customization local directory. 

For example the local source in `./teitorelaxng --localsource=/path/to/localsource/odd.xml /path/to/customization/odd.xml` would be changed within odd2odd.xsl to  `/path/to/customization//path/to/localsource/odd.xml`

This pull request introduces a condition to pass the localsource parameter unchanged.