### PR TITLE
Fix missing first text node, a [, in certain references.

### DIFF
--- a/docx/from/pass2.xsl
+++ b/docx/from/pass2.xsl
@@ -599,13 +599,15 @@ of this software, even if advised of the possibility of such damage.
 	  <xsl:value-of select="$target"/>
 	</xsl:processing-instruction>
 	<xsl:choose>
-          <xsl:when test="(count(.//text()) &lt; 2) or (count(tei:ref) &gt; 1)">
+          <xsl:when test="(count(.//text()) &lt; 3) or (count(tei:ref) &gt; 1)">
             <xsl:apply-templates mode="pass2"/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="(.//text())[1]"/>
+            <xsl:value-of select="./text()[1]|(.//node()[not(self::tei:ref) and self::text()])[1]"/>
             <xsl:apply-templates select="*" mode="pass2"/>
-            <xsl:value-of select="remove(text(), 1)"/>
+            <xsl:if test="./text()[last()]">
+              <xsl:value-of select="(.//node()[not(self::tei:ref) and self::text()])[last()]"/>
+            </xsl:if>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>

--- a/docx/from/pass2.xsl
+++ b/docx/from/pass2.xsl
@@ -599,11 +599,11 @@ of this software, even if advised of the possibility of such damage.
 	  <xsl:value-of select="$target"/>
 	</xsl:processing-instruction>
 	<xsl:choose>
-          <xsl:when test="count(text()) &lt; 2">
+          <xsl:when test="(count(.//text()) &lt; 2) or (count(tei:ref) &gt; 1)">
             <xsl:apply-templates mode="pass2"/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="text()[1]"/>
+            <xsl:value-of select="(.//text())[1]"/>
             <xsl:apply-templates select="*" mode="pass2"/>
             <xsl:value-of select="remove(text(), 1)"/>
           </xsl:otherwise>


### PR DESCRIPTION
I can provide an example doc, where I compiled the few forms of references I've noticed in my set, this fixes the issue for me, where a `hi` element actually containing text was ignored in certain situations because of this:
https://github.com/TEIC/Stylesheets/blob/master/docx/from/pass2.xsl#L330

Can you think of a better way?

Here's the example Docx, if you're interested: https://dl.dropboxusercontent.com/u/30920/referenceexamples.docx

Look for square brackets getting lost in the current conversion, it's most visually obvious in the Docx to HTML conversion, but is already present in the TEI.
