### PR TITLE
Apply templates on any included contentPart

### DIFF
--- a/docx/from/docxtotei.xsl
+++ b/docx/from/docxtotei.xsl
@@ -549,6 +549,29 @@ of this software, even if advised of the possibility of such damage.
      </xsl:if>
    </xsl:template>
 
+   <!-- Process contentParts which link to customXML. Can contain,
+        e.g., MathML.
+        https://msdn.microsoft.com/en-us/library/documentformat.openxml.wordprocessing.contentpart%28v=office.14%29.aspx
+        -->
+   <xsl:template match="w:contentPart">
+     <xsl:variable name="rid" select="@r:id"/>
+     <!-- Get the rel information -->
+     <xsl:variable name="rel" select="document($relsDoc)//rel:Relationship[@Id=$rid]"/>
+     <!-- Note that -->
+     <!--   https://msdn.microsoft.com/en-us/library/documentformat.openxml.wordprocessing.contentpart%28v=office.14%29.aspx -->
+     <!-- lists 2 possible values for the type (.../2006/customXml and -->
+     <!-- .../2006/relationships/customXml) I believe this is the correct -->
+     <!-- one. -->
+     <xsl:if test="$rel/@Type = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXml' and $rel/@Target">
+       <xsl:apply-templates select="document(concat($wordDirectory, 'word/', $rel/@Target))"/>
+     </xsl:if>
+   </xsl:template>
+
+   <!-- Pass through any MathML content. -->
+   <xsl:template match="mml:math">
+     <xsl:copy-of select="."/>
+   </xsl:template>
+
    <xsl:template match="w:instrText"/>
 
     <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">


### PR DESCRIPTION
`contentPart` can contain XML format, e.g. MathML or SVG. See
  https://msdn.microsoft.com/en-us/library/documentformat.openxml.wordprocessing.contentpart%28v=office.14%29.aspx
for more information.

Also pass through any MathML content.

We are currently using https://github.com/jure/mathtype_to_mathml as a preprocessing step to transform docx with mathtype into docx with embedded MathML for transformation to HTML using oxgarage.

Note that while technically allowed, I have not been able to get Word or LibreOffice to open files with MathML embedded in this way.

Please let me know if you have questions. This change should not have any effect at all on docx files without `contentPart` data.
