### PR TITLE
TEI address element is wrongly converted to HTML address element (#261)

### DIFF
--- a/css/tei.css
+++ b/css/tei.css
@@ -481,6 +481,11 @@ span.note:after{
 span.note{
     font-size:smaller;
 }
+/* address */
+span.address {
+    display: block;
+    font-style: italic;
+}
 /* images */
 img.display{
     margin-top:10pt;

--- a/html/html_core.xsl
+++ b/html/html_core.xsl
@@ -93,10 +93,10 @@ of this software, even if advised of the possibility of such damage.
     <desc>Process element address</desc>
   </doc>
   <xsl:template match="tei:address">
-    <address>
+    <span class="address">
       <xsl:call-template name="makeRendition"/>
       <xsl:apply-templates/>
-    </address>
+    </span>
   </xsl:template>
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
     <desc>Process element author</desc>


### PR DESCRIPTION
According to the decision of the Stylesheet co-op group, the output from `<address>` is changed to `<span class="address">` and the CSS selector span.address is added, see the discussion on: https://github.com/TEIC/Stylesheets/issues/261