### PR TITLE
supplying ns prefix for MEI

### DIFF
--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -1308,20 +1308,23 @@ of this software, even if advised of the possibility of such damage.
     <xsl:for-each select="$e">
       <xsl:variable name="myns" select="ancestor::tei:elementSpec/@ns"/>
       <xsl:choose>
-	<xsl:when test="not($myns) or $myns='http://www.tei-c.org/ns/1.0'">
-	  <xsl:text>tei:</xsl:text>
-	</xsl:when>
-	<xsl:otherwise>
-	  <xsl:choose>
-	    <xsl:when test="ancestor::tei:schemaSpec//sch:ns[@uri=$myns]">
-	      <xsl:value-of
-		  select="concat(ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix,':')"/>
-	    </xsl:when>
-	    <xsl:otherwise>
-	      <xsl:message terminate="yes">schematron rule cannot work out prefix for <xsl:value-of select="ancestor::tei:elementSpec/@ident"/></xsl:message>
-	    </xsl:otherwise>
-	  </xsl:choose>
-	</xsl:otherwise>
+       	<xsl:when test="not($myns) or $myns='http://www.tei-c.org/ns/1.0'">
+       	  <xsl:text>tei:</xsl:text>
+       	</xsl:when>
+        <xsl:when test="$myns = 'http://www.music-encoding.org/ns/mei'">
+          <xsl:text>mei:</xsl:text>
+        </xsl:when>
+       	<xsl:otherwise>
+       	  <xsl:choose>
+       	    <xsl:when test="ancestor::tei:schemaSpec//sch:ns[@uri=$myns]">
+       	      <xsl:value-of
+       		  select="concat(ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix,':')"/>
+       	    </xsl:when>
+       	    <xsl:otherwise>
+       	      <xsl:message terminate="yes">schematron rule cannot work out prefix for <xsl:value-of select="ancestor::tei:elementSpec/@ident"/></xsl:message>
+       	    </xsl:otherwise>
+       	  </xsl:choose>
+       	</xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
   </xsl:function>


### PR DESCRIPTION
I recently had trouble creating an MEI 3.0 schema with the TEI Stylesheets because it failed to work out the prefix for the MEI namespace needed within the function `tei:generate-nsprefix-schematron`. The following pull request simply supplies this value.