### PR TITLE
Add makeAnchor to tei:ab where it generates html:div

### DIFF
--- a/html/html_core.xsl
+++ b/html/html_core.xsl
@@ -66,6 +66,9 @@ of this software, even if advised of the possibility of such damage.
       </xsl:when>
       <xsl:when test="parent::tei:sp">
         <div>
+	  <xsl:if test="@xml:id">
+	    <xsl:call-template name="makeAnchor"/>
+	  </xsl:if>
           <xsl:call-template name="makeRendition">
 	    <xsl:with-param name="default">spProse</xsl:with-param>
 	  </xsl:call-template>
@@ -74,6 +77,9 @@ of this software, even if advised of the possibility of such damage.
       </xsl:when>
       <xsl:otherwise>
         <div>
+	  <xsl:if test="@xml:id">
+	    <xsl:call-template name="makeAnchor"/>
+	  </xsl:if>
           <xsl:call-template name="makeRendition">
 	    <xsl:with-param name="default">false</xsl:with-param>
 	  </xsl:call-template>


### PR DESCRIPTION
In the digital edition http://nl.ijs.si/e-zrc/kapelski/index-en.html we now make reference (via ref/@target) to ab/@xml:id, which didn't work in HTML because tei:ab/@xml:id didn't get mapped to html:div/@id. And this is now fixed.
Btw., this is my first pull request, so I hope it is kosher!