### PR TITLE
Implementation of sorted diffing to make Test more robust against software version changes.

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -231,12 +231,12 @@ test-epub: css
 	java -Djava.awt.headless=true -jar ../lib/epubcheck3.jar  test.epub
 	unzip -t test.epub > test.epub.listing
 	if [ $(REGENERATING) -ne 1 ]; \
-		then diff  test.epub.listing expected-results/test.epub.listing; fi
+		then bash -c 'diff  <(sort test.epub.listing) <(sort expected-results/test.epub.listing)'; fi
 	rm test.epub.listing
 	$(BINDIR)/teitoepub  --fileperpage test.xml test-pages.epub
 	unzip -t test-pages.epub > test.epub.listing2
 	if [ $(REGENERATING) -ne 1 ]; \
-		then diff  test.epub.listing2 expected-results/test.epub.listing2; fi
+		then bash -c 'diff  <(sort test.epub.listing2) <(sort expected-results/test.epub.listing2)'; fi
 	rm test.epub.listing2
 
 test-rdf:
@@ -265,9 +265,9 @@ test-odt:   test.rng
 	unzip -o -q test.xml.odt content.xml
 	xmllint --format content.xml > content.xml.odt.listing
 	if [ $(REGENERATING) -ne 1 ]; \
-		then diff  test.xml.odt.listing expected-results/test.xml.odt.listing; fi
+		then bash -c 'diff  <(sort test.xml.odt.listing) <(sort expected-results/test.xml.odt.listing)'; fi
 	if [ $(REGENERATING) -ne 1 ]; \
-		then diff  content.xml.odt.listing expected-results/content.xml.odt.listing; fi
+		then bash -c 'diff  <(sort content.xml.odt.listing) <(sort expected-results/content.xml.odt.listing)'; fi
 	$(BINDIR)/odttotei test7.odt test7.xml
 	$(JING) test.rng test7.xml
 	if [ $(REGENERATING) -ne 1 ]; \


### PR DESCRIPTION
Recent version of debian-based OSes have software changes which result in the sequence of items in a zip file listing being in a different order from those in older versions. When we do diffs of file listings against expected-results in the Stylesheets Tests, those tests fail because the expected-results are in a different order. The sequence of items is insignificant, so sorting both the test file and the expected-results file before diffing results in an equally rigorous test but makes it more robust against software changes, allowing the tests to succeed on (for example) Ubuntu 18.04, the current LTS.