### PR TITLE
adding rendering of ref, gi and att inside desc

### DIFF
--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -2456,6 +2456,17 @@ select="$makeDecls"/></xsl:message>
   </xsl:template>
 
 
+  <xsl:template match="tei:ref[@target]">
+    <a xmlns="http://www.w3.org/1999/xhtml"  href="{@target}"><xsl:value-of select="."/></a>
+  </xsl:template>
+  
+  <xsl:template match="tei:gi">
+    <code xmlns="http://www.w3.org/1999/xhtml">&lt;<xsl:value-of select="."/>&gt;</code>
+  </xsl:template>
+  <xsl:template match="tei:att">
+    <code xmlns="http://www.w3.org/1999/xhtml">@<xsl:value-of select="."/></code>
+  </xsl:template>
+	
   <xsl:template name="schematronInContent">
     <xsl:for-each select="tei:constraintSpec/tei:constraint/*">
       <xsl:call-template name="processSchematron"/>


### PR DESCRIPTION
I wanted the Relax-NG output from my ODD to render ref[@target] as link and gi | att as code, adding the three small templates does it for this purpose and gets visualized in oXygen, but I ignore other possible implications. I have tested modifying my local version of the stylesheets.