### PR TITLE
Consider page ranges given as attributes in biblStruct//biblScope

### DIFF
--- a/common/common_core.xsl
+++ b/common/common_core.xsl
@@ -817,6 +817,13 @@ of this software, even if advised of the possibility of such damage.
 			       name="letters">pp. </xsl:with-param>
 			 </xsl:call-template>
                </xsl:when>
+               <xsl:when test="./@from and ./@to">
+				<xsl:call-template name="makeText">
+					<xsl:with-param name="letters">
+					pp. <xsl:value-of select="@from"/>-<xsl:value-of select="@to"/>
+					</xsl:with-param>
+			 </xsl:call-template>
+               </xsl:when>
                <xsl:otherwise>
 	                 <xsl:call-template name="makeText">
 			   <xsl:with-param


### PR DESCRIPTION
The previous code gave as output a "p." followed by nothin.

Example item created by GROBID:

<biblStruct xml:id="b47">
	<analytic>
		<title level="a" type="main">Chronic inflammation (inflammaging) and its potential contribution to age-associated diseases</title>
		<author>
			<persName xmlns="http://www.tei-c.org/ns/1.0"><forename type="first">C</forename><surname>Franceschi</surname></persName>
		</author>
		<author>
			<persName xmlns="http://www.tei-c.org/ns/1.0"><forename type="first">J</forename><surname>Campisi</surname></persName>
		</author>
		<idno type="doi">doi:10.1093/gerona/glu057</idno>
	</analytic>
	<monogr>
		<title level="j">J Gerontol A Biol Sci Med Sci</title>
		<imprint>
			<biblScope unit="volume">69</biblScope>
			<biblScope unit="issue">1</biblScope>
			<biblScope unit="page" from="4" to="9" />
			<date type="published" when="2014" />
		</imprint>
	</monogr>
	<note>suppl</note>
</biblStruct>