### PR TITLE
set localsource parameter once for build process 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SFUSER=rahtz
 JING=jing
-DEFAULTSOURCE=https://www.tei-c.org/release/xml/tei/odd/p5subset.xml
+DEFAULTSOURCE=https://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml
 SAXON=java -jar lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE)
 DOTSAXON=java -jar ../lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE)
 DOTDOTSAXON=java -jar ../../lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE) 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 SFUSER=rahtz
 JING=jing
-SAXON=java -jar lib/saxon9he.jar
-DOTDOTSAXON=java -jar ../../lib/saxon9he.jar
-DOTSAXON=java -jar ../lib/saxon9he.jar
+DEFAULTSOURCE=https://www.tei-c.org/release/xml/tei/odd/p5subset.xml
+SAXON=java -jar lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE)
+DOTSAXON=java -jar ../lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE)
+DOTDOTSAXON=java -jar ../../lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE) 
 SAXON_ARGS=-ext:on
-
 DIRS=bibtex cocoa common csv docx dtd docbook epub epub3 fo html wordpress markdown html5 json latex latex nlm odd odds odt p4 pdf profiles/default rdf relaxng rnc schematron simple slides tbx tcp lite tite tools txt html xsd xlsx pdf verbatimxml
 
 SCRIPTS=bin/*to*
@@ -102,7 +102,7 @@ teioo.jar:
 
 test: clean build common names debversion
 	@echo BUILD Run tests
-	(cd Test; make)
+	(cd Test; make DEFAULTSOURCE=$(DEFAULTSOURCE))
 
 dist: clean release
 	-rm -f tei-xsl-`cat VERSION`.zip

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -3,7 +3,7 @@ VERSION=`cat VERSION`
 REGENERATING=0
 # 0 = do diff; 1 = dont do diff
 BINDIR=../bin
-DEFAULTSOURCE=https://www.tei-c.org/release/xml/tei/odd/p5subset.xml
+DEFAULTSOURCE=https://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml
 SAXONOPT=useFixedDate=true
 SAXON=java -Djava.awt.headless=true -jar ../lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE)
 DOTDOTSAXON=java -Djava.awt.headless=true -jar ../../lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE)

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -1,13 +1,15 @@
 #added REGERATION option (LB 2015-12-16)
 VERSION=`cat VERSION`
-FLAG=
 REGENERATING=0
 # 0 = do diff; 1 = dont do diff
 BINDIR=../bin
+DEFAULTSOURCE=https://www.tei-c.org/release/xml/tei/odd/p5subset.xml
 SAXONOPT=useFixedDate=true
-SAXON=java -Djava.awt.headless=true -jar ../lib/saxon9he.jar
-DOTDOTSAXON=java -Djava.awt.headless=true -jar ../../lib/saxon9he.jar
-JING=java -Djava.awt.headless=true -jar ../lib/lib/jing-20120724.0.0.jar
+SAXON=java -Djava.awt.headless=true -jar ../lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE)
+DOTDOTSAXON=java -Djava.awt.headless=true -jar ../../lib/saxon9he.jar defaultSource=$(DEFAULTSOURCE)
+JING=java -Djava.awt.headless=true -jar ../lib/lib/jing-20120724.0.0.jar 
+# flags used for the commands running from $(BINDIR), e.g. `bin/teitorelaxng` 
+FLAGS=--localsource=$(DEFAULTSOURCE)
 OXY=/usr/share/oxygen
 SCRIPTS=teitobibtex \
 	teitodocbook \
@@ -32,7 +34,7 @@ SCHEMASCRIPTS=teitornc \
 default: test.rng test-to-html test-p4top5 test-oddity test-scripts test-namespaces test-from-html test-latex test-fo test-to-docx test-from-docx test-xlsx test-rdf test-text test-odt test-markdown test-cocoa test-epub
 
 test.rng:
-	$(BINDIR)/teitorelaxng --odd test.odd test.rng
+	$(BINDIR)/teitorelaxng $(FLAGS) --odd test.odd test.rng
 	perl -i -p -e 's/generated from ODD source.*//' test.rng
 	xmllint --format test.rng > temp; mv temp test.rng
 	perl -i -pe 'BEGIN{undef $$/;} s/<!--\n ?Schema[^>]+>//smg' test.rng
@@ -54,7 +56,7 @@ test-to-html: css
 	$(SAXON) test.xml ../profiles/ota/html/to.xsl cssFile=../tei.css $(SAXONOPT)  | xmllint --format - | perl cleanup.pl > test-ota.html
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test-ota.html expected-results/test-ota.html; fi
-	$(BINDIR)/teitohtml5 test.xml test.html5
+	$(BINDIR)/teitohtml5 $(FLAGS) test.xml test.html5
 	xmllint --encode utf-8 --format test.html5 | perl cleanup.pl > test.temp
 	mv test.temp test.html5
 	if [ $(REGENERATING) -ne 1 ]; \
@@ -136,20 +138,20 @@ test-from-html:
 test-markdown:
 	@echo BUILD: testing markdown
 	@echo BUILD: markdown to tei
-	$(BINDIR)/markdowntotei mdtest1.md mdtest1.xml
+	$(BINDIR)/markdowntotei $(FLAGS) mdtest1.md mdtest1.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  mdtest1.xml expected-results/mdtest1.xml; fi
 	@echo BUILD: tei to markdown
-	$(BINDIR)/teitomarkdown test.xml mdtest2.md
+	$(BINDIR)/teitomarkdown $(FLAGS) test.xml mdtest2.md
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  mdtest2.md expected-results/mdtest2.md; fi
 
 test-cocoa:
 	@echo BUILD: testing cocoa  to TEI
-	$(BINDIR)/cocoatotei cocoatest.txt cocoatest.xml
+	$(BINDIR)/cocoatotei $(FLAGS) cocoatest.txt cocoatest.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  cocoatest.xml expected-results/cocoatest.xml; fi
-	$(BINDIR)/cocoatotei cocoatest2.txt cocoatest2.xml
+	$(BINDIR)/cocoatotei $(FLAGS) cocoatest2.txt cocoatest2.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  cocoatest2.xml expected-results/cocoatest2.xml; fi
 
@@ -225,15 +227,15 @@ test-fo:
 
 test-epub: css
 	@echo BUILD: testing epub
-	$(BINDIR)/teitoepub3  test.xml test.epub
+	$(BINDIR)/teitoepub3 $(FLAGS) test.xml test.epub
 	java -Djava.awt.headless=true -jar ../lib/epubcheck3.jar test.epub
-	$(BINDIR)/teitoepub  test.xml test.epub
+	$(BINDIR)/teitoepub $(FLAGS) test.xml test.epub
 	java -Djava.awt.headless=true -jar ../lib/epubcheck3.jar  test.epub
 	unzip -t test.epub > test.epub.listing
 	if [ $(REGENERATING) -ne 1 ]; \
 		then bash -c 'diff  <(sort test.epub.listing) <(sort expected-results/test.epub.listing)'; fi
 	rm test.epub.listing
-	$(BINDIR)/teitoepub  --fileperpage test.xml test-pages.epub
+	$(BINDIR)/teitoepub $(FLAGS) --fileperpage test.xml test-pages.epub
 	unzip -t test-pages.epub > test.epub.listing2
 	if [ $(REGENERATING) -ne 1 ]; \
 		then bash -c 'diff  <(sort test.epub.listing2) <(sort expected-results/test.epub.listing2)'; fi
@@ -247,20 +249,20 @@ test-rdf:
 
 test-text:
 	@echo BUILD: testing text
-	$(BINDIR)/teitotxt test14.xml test.text
+	$(BINDIR)/teitotxt $(FLAGS) test14.xml test.text
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test.text expected-results/test.text; fi
 
 test-xlsx:
 	@echo BUILD: testing xlsx
-	$(BINDIR)/xlsxtotei test.xlsx test.xlsx.xml
+	$(BINDIR)/xlsxtotei $(FLAGS) test.xlsx test.xlsx.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test.xlsx.xml expected-results/test.xlsx.xml; fi
 
 test-odt:   test.rng
 	(cd ..; $(MAKE) names)
 	@echo BUILD: testing odt
-	$(BINDIR)/teitoodt test.xml
+	$(BINDIR)/teitoodt $(FLAGS) test.xml
 	unzip -t test.xml.odt | sort > test.xml.odt.listing
 	unzip -o -q test.xml.odt content.xml
 	xmllint --format content.xml > content.xml.odt.listing
@@ -268,65 +270,65 @@ test-odt:   test.rng
 		then bash -c 'diff  <(sort test.xml.odt.listing) <(sort expected-results/test.xml.odt.listing)'; fi
 	if [ $(REGENERATING) -ne 1 ]; \
 		then bash -c 'diff  <(sort content.xml.odt.listing) <(sort expected-results/content.xml.odt.listing)'; fi
-	$(BINDIR)/odttotei test7.odt test7.xml
+	$(BINDIR)/odttotei $(FLAGS) test7.odt test7.xml
 	$(JING) test.rng test7.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test7.xml expected-results/test7.xml; fi
 
 test-from-docx: test.rng
 	@echo BUILD: testing from-docx
-	$(BINDIR)/docxtotei test-indexes.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) test-indexes.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > test-indexes.xml  && rm temp.xml
 	$(JING) test.rng test-indexes.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test-indexes.xml expected-results/test-indexes.xml; fi
-	$(BINDIR)/docxtotei test11.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) test11.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl> test11.xml  && rm temp.xml
 	$(JING) test.rng test11.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test11.xml expected-results/test11.xml; fi
-	$(BINDIR)/docxtotei --profile=sciencejournal test11.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) --profile=sciencejournal test11.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl> test11a.xml  && rm temp.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test11a.xml expected-results/test11a.xml; fi
-	$(BINDIR)/docxtotei test19.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) test19.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > test19.xml  && rm temp.xml
 	$(JING) test.rng test19.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test19.xml expected-results/test19.xml; fi
-	$(BINDIR)/docxtotei test18.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) test18.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > test18.xml  && rm temp.xml
 	$(JING) test.rng test18.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test18.xml expected-results/test18.xml; fi
-	$(BINDIR)/docxtotei test39.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) test39.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > test39.xml  && rm temp.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test39.xml expected-results/test39.xml; fi
-	$(BINDIR)/docxtotei hyperlinktest.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) hyperlinktest.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > hyperlinktest.xml  && rm temp.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  hyperlinktest.xml expected-results/hyperlinktest.xml; fi
-	$(BINDIR)/docxtotei --profile=transcription test-rtf2tei.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) --profile=transcription test-rtf2tei.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > test-rtf2tei.xml  && rm temp.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test-rtf2tei.xml expected-results/test-rtf2tei.xml; fi
-	$(BINDIR)/docxtotei --profile=transcription test29.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) --profile=transcription test29.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > test29.xml  && rm temp.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test29.xml expected-results/test29.xml; fi
-	$(BINDIR)/docxtotei --profile=tei test37.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) --profile=tei test37.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > test37.xml  && rm temp.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test37.xml expected-results/test37.xml; fi
-	$(BINDIR)/docxtotei --profile=tei test40.docx temp.xml
+	$(BINDIR)/docxtotei $(FLAGS) --profile=tei test40.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > test40.xml  && rm temp.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test40.xml expected-results/test40.xml; fi
 
 test-to-docx:
 	@echo BUILD: testing to-docx
-	$(BINDIR)/teitodocx test.xml
+	$(BINDIR)/teitodocx $(FLAGS) test.xml
 	unzip -p test.xml.docx word/document.xml | xmllint --format - > test.xml.docx.document
 	unzip -p test.xml.docx docProps/core.xml | xmllint --format - | sed 's/>20.*Z</>20Z</' > test.xml.docx.core
 	if [ $(REGENERATING) -ne 1 ]; \
@@ -334,51 +336,51 @@ test-to-docx:
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test.xml.docx.core expected-results/test.xml.docx.core; fi
 	rm test.xml.docx.document
-	$(BINDIR)/teitodocx test6.xml
+	$(BINDIR)/teitodocx $(FLAGS) test6.xml
 	unzip -p test6.xml.docx word/document.xml | xmllint --format - > test6.xml.docx.document
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test6.xml.docx.document expected-results/test6.xml.docx.document; fi
 	rm test6.xml.docx.document
-	$(BINDIR)/teitodocx testnotes1.xml
+	$(BINDIR)/teitodocx $(FLAGS) testnotes1.xml
 	unzip -p testnotes1.xml.docx word/document.xml | xmllint --format - > testnotes1.xml.docx.document
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  testnotes1.xml.docx.document expected-results/testnotes1.xml.docx.document; fi
 	rm testnotes1.xml.docx.document
 	$(SAXON) testoucscourses.xml ../profiles/default/p4/from.xsl > testoucscoursesp5.xml
-	$(BINDIR)/teitodocx --profile=oucscourses testoucscoursesp5.xml testoucscourses.xml.docx
+	$(BINDIR)/teitodocx $(FLAGS) --profile=oucscourses testoucscoursesp5.xml testoucscourses.xml.docx
 	rm testoucscourses.xml.docx testoucscoursesp5.xml
 
 test-oddity: css
 	@echo BUILD: testing oddity
-	$(BINDIR)/teitohtml5 $(FLAG) --summaryDoc --odd test.odd test.odd.html
+	$(BINDIR)/teitohtml5 $(FLAGS) --summaryDoc --odd test.odd test.odd.html
 	xmllint --encode utf-8 --format test.odd.html | perl cleanup.pl> test.temp ; mv test.temp test.odd.html
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test.odd.html expected-results/test.odd.html; fi
-	$(BINDIR)/teitoodd test.odd test.processedodd
+	$(BINDIR)/teitoodd $(FLAGS) test.odd test.processedodd
 	$(SAXON) test.processedodd ../odds/extract-isosch.xsl > test.isosch
 	perl -i -p -e 's/generated .* by /generated by /' test.isosch
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test.isosch expected-results/test.isosch; fi
-	$(BINDIR)/teitornc  $(FLAG) test21.odd test21.odd.rnc
+	$(BINDIR)/teitornc $(FLAGS) test21.odd test21.odd.rnc
 	perl -p -i -e 's/generated from ODD source.*//' test21.odd.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' test21.odd.rnc
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test21.odd.rnc expected-results/test21.odd.rnc; fi
-	$(BINDIR)/teitornc  $(FLAG) test15.odd test15.odd.rnc
+	$(BINDIR)/teitornc  $(FLAGS) test15.odd test15.odd.rnc
 	perl -p -i -e 's/generated from ODD source.*//' test15.odd.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' test15.odd.rnc
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test15.odd.rnc expected-results/test15.odd.rnc; fi
-	$(BINDIR)/teitohtml5 $(FLAG) --summaryDoc --lang=es --profile=tei --odd test15.odd test15.odd.html
+	$(BINDIR)/teitohtml5 $(FLAGS) --summaryDoc --lang=es --profile=tei --odd test15.odd test15.odd.html
 	xmllint --encode utf-8 --format test15.odd.html | perl cleanup.pl> test.temp ; mv test.temp test15.odd.html
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test15.odd.html expected-results/test15.odd.html; fi
 	$(SAXON) -it:main  -xsl:../tools/oddbyexample.xsl corpus=`pwd`/bare | sed 's/<p>Derived from.*/<p\/>/' >  oddbyexample.odd
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  oddbyexample.odd expected-results/oddbyexample.odd; fi
-	$(BINDIR)/teitoxsd  $(FLAG) oddbyexample.odd  oddbyexample.xsd
-	$(BINDIR)/teitornc  $(FLAG) oddbyexample.odd  oddbyexample.rnc
-	$(BINDIR)/teitodtd  $(FLAG) oddbyexample.odd  oddbyexample.dtd
+	$(BINDIR)/teitoxsd  $(FLAGS) oddbyexample.odd  oddbyexample.xsd
+	$(BINDIR)/teitornc  $(FLAGS) oddbyexample.odd  oddbyexample.rnc
+	$(BINDIR)/teitodtd  $(FLAGS) oddbyexample.odd  oddbyexample.dtd
 	$(JING) -c oddbyexample.rnc bare/test2.xml
 	$(JING) oddbyexample.xsd bare/test2.xml
 	xmllint --noout --dtdvalid oddbyexample.dtd bare/test2.xml
@@ -390,8 +392,8 @@ test-oddity: css
 	perl -i -pe 'BEGIN{undef $$/;} s/<\?TEIVERSION[^?]+\?>//smg' testdrama.compiled.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  testdrama.compiled.xml expected-results/testdrama.compiled.xml; fi
-	$(BINDIR)/teitornc $(FLAG) test30.odd test30.rnc
-	$(BINDIR)/teitodtd $(FLAG) test30.odd test30.dtd
+	$(BINDIR)/teitornc $(FLAGS) test30.odd test30.rnc
+	$(BINDIR)/teitodtd $(FLAGS) test30.odd test30.dtd
 	perl -p -i -e 's/generated from ODD source .*//' test30.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' test30.rnc
 	perl -p -i -e 's/generated from ODD source .*//' test30.dtd
@@ -405,9 +407,9 @@ test-oddity: css
 # MDH 2017-01-07: THE FOLLOWING LINES WILL integrate LB's new pure ODD 
 # master test to replace originals, BUT ONLY WHEN THINGS ARE WORKING PROPERLY.
 # Generate DTD from ODD.
-#	$(BINDIR)/teitodtd $(FLAG) testODD.odd testODD.dtd
+#	$(BINDIR)/teitodtd $(FLAGS) testODD.odd testODD.dtd
 # Generate RNC from the same file.
-#	$(BINDIR)/teitornc $(FLAG) testODD.odd testODD.rnc
+#	$(BINDIR)/teitornc $(FLAGS) testODD.odd testODD.rnc
 # Trim all sorts of piffle out of the DTD and RNC before we compare them with the expected results.
 #	perl -p -i -e 's/generated from ODD source .*//' testODD.dtd
 #	perl -i -pe 'BEGIN{undef $$/;} s/<!--\nDTD[^>]*-->\n//smg' testODD.dtd
@@ -420,8 +422,8 @@ test-oddity: css
 #		then diff  testODD.rnc expected-results/testODD.rnc; fi
 # NOTE: THERE SHOULD BE VALIDATION OF AN INSTANCE FILE AGAINST THE DTD HERE.	
 # OLD ORIGINAL CODE STILL BEING USED FOR THE MOMENT.
-	$(BINDIR)/teitodtd $(FLAG) test-pure.odd test-pure.dtd
-	$(BINDIR)/teitornc $(FLAG) test-pure.odd test-pure.rnc
+	$(BINDIR)/teitodtd $(FLAGS) test-pure.odd test-pure.dtd
+	$(BINDIR)/teitornc $(FLAGS) test-pure.odd test-pure.rnc
 	xmllint --noout --dtdvalid test-pure.dtd test-pure.xml
 	perl -p -i -e 's/generated from ODD source .*//' test-pure.dtd
 	perl -i -pe 'BEGIN{undef $$/;} s/<!--\nDTD[^>]*-->\n//smg' test-pure.dtd
@@ -431,13 +433,13 @@ test-oddity: css
 		then diff  test-pure.rnc expected-results/test-pure.rnc; fi
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test-pure.dtd expected-results/test-pure.dtd; fi
-	$(BINDIR)/teitohtml $(FLAG) --odd test-pure.odd test-pure.odd.html
+	$(BINDIR)/teitohtml $(FLAGS) --odd test-pure.odd test-pure.odd.html
 	xmllint --encode utf-8 --format test-pure.odd.html | perl cleanup.pl> test.temp ; mv test.temp test-pure.odd.html
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test-pure.odd.html expected-results/test-pure.odd.html; fi
-	$(BINDIR)/teitodtd $(FLAG) test-pure2.odd test-pure2.dtd
-	$(BINDIR)/teitornc $(FLAG) test-pure2.odd test-pure2.rnc
-	$(BINDIR)/teitohtml $(FLAG) --odd test-pure2.odd test-pure2.odd.html
+	$(BINDIR)/teitodtd $(FLAGS) test-pure2.odd test-pure2.dtd
+	$(BINDIR)/teitornc $(FLAGS) test-pure2.odd test-pure2.rnc
+	$(BINDIR)/teitohtml $(FLAGS) --odd test-pure2.odd test-pure2.odd.html
 	xmllint --noout --dtdvalid test-pure2.dtd test-pure2.xml
 	xmllint --encode utf-8 --format test-pure2.odd.html | perl cleanup.pl> test.temp ; mv test.temp test-pure2.odd.html
 	perl -p -i -e 's/generated from ODD source .*//' test-pure2.dtd
@@ -466,15 +468,15 @@ test-oddity: css
 	rm test.odd2xslstripspace
 
 moreoddity:
-	$(BINDIR)/teitoxsd $(FLAG) test.odd test.xsd
-	$(BINDIR)/teitodtd test.odd test.dtd
-	$(BINDIR)/teitornc test.odd test.rnc
+	$(BINDIR)/teitoxsd $(FLAGS) test.odd test.xsd
+	$(BINDIR)/teitodtd $(FLAGS) test.odd test.dtd
+	$(BINDIR)/teitornc $(FLAGS) test.odd test.rnc
 
 test-namespaces:
 	@echo BUILD: testing namespaces
 # This test checks the rnc files so that to make sure we are testing
 # what we think we are testing.
-	$(BINDIR)/teitornc test33.odd test33.rnc
+	$(BINDIR)/teitornc $(FLAGS) test33.odd test33.rnc
 	perl -p -i -e 's/generated from ODD source .*//' test33.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' test33.rnc
 	if [ $(REGENERATING) -ne 1 ]; \
@@ -483,7 +485,7 @@ test-namespaces:
 	perl -p -i -e 's/"date" : "\d+-\d+\-\d+T\d+:\d+:\d+Z",//' test33.json
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test33.json expected-results/test33.json; fi
-	$(BINDIR)/teitornc test34.odd test34.rnc
+	$(BINDIR)/teitornc $(FLAGS) test34.odd test34.rnc
 	perl -p -i -e 's/generated from ODD source .*//' test34.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' test34.rnc
 	if [ $(REGENERATING) -ne 1 ]; \
@@ -497,11 +499,11 @@ test-namespaces:
 	perl -p -i -e 's/"date" : "\d+-\d+\-\d+T\d+:\d+:\d+Z",//' test34.combined.json
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test34.combined.json expected-results/test34.combined.json; fi
-	$(BINDIR)/teitohtml --odd --summaryDoc test34.odd test34.odd.html
+	$(BINDIR)/teitohtml $(FLAGS) --odd --summaryDoc test34.odd test34.odd.html
 	xmllint --encode utf-8 --format test34.odd.html | perl cleanup.pl> test.temp ; mv test.temp test34.odd.html
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  test34.odd.html expected-results/test34.odd.html; fi
-	$(BINDIR)/teitornc test35.odd test35.rnc
+	$(BINDIR)/teitornc $(FLAGS) test35.odd test35.rnc
 	perl -p -i -e 's/generated from ODD source .*//' test35.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' test35.rnc
 	if [ $(REGENERATING) -ne 1 ]; \
@@ -509,7 +511,7 @@ test-namespaces:
 
 test-scripts:
 	for i in $(SCRIPTS); do $(BINDIR)/$$i $(FLAGS) maria.xml $$i.result && rm $$i.result; done
-	$(BINDIR)/teitoodd test16.odd temp.odd
+	$(BINDIR)/teitoodd $(FLAGS) test16.odd temp.odd
 	for i in $(SCHEMASCRIPTS) ; do $(BINDIR)/$$i $(FLAGS) temp.odd $$i.result && rm $$i.result; done
 	rm temp.odd
 

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -390,6 +390,7 @@ test-oddity: css
 	$(SAXON) -s:testdrama.odd -xsl:../odds/odd2odd.xsl -o:testdrama.compiled.xml
 	perl -p -i -e 's+ xml:base=".*testdrama.odd"++' testdrama.compiled.xml
 	perl -i -pe 'BEGIN{undef $$/;} s/<\?TEIVERSION[^?]+\?>//smg' testdrama.compiled.xml
+	perl -i -pe 's+(schemaSpec.*source=")$(DEFAULTSOURCE)+$$1https://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml+' testdrama.compiled.xml
 	if [ $(REGENERATING) -ne 1 ]; \
 		then diff  testdrama.compiled.xml expected-results/testdrama.compiled.xml; fi
 	$(BINDIR)/teitornc $(FLAGS) test30.odd test30.rnc

--- a/Test/expected-results/test.rng
+++ b/Test/expected-results/test.rng
@@ -223,7 +223,7 @@
     <optional>
       <attribute name="unit">
         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">names the unit used for the measurement
-Suggested values include: 1] cm (centimetres) ; 2] mm (millimetres) ; 3] in (inches) ; 4] lines; 5] chars (characters) </a:documentation>
+Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inches); 4] lines; 5] chars (characters)</a:documentation>
         <choice>
           <value>cm</value>
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(centimetres) </a:documentation>
@@ -993,7 +993,7 @@ Suggested values include: 1] internal; 2] external; 3] conjecture</a:documentati
     <optional>
       <attribute name="unit">
         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the units used for the measurement, usually using the standard symbol for the desired units.
-Suggested values include: 1] m (metre) ; 2] kg (kilogram) ; 3] s (second) ; 4] Hz (hertz) ; 5] Pa (pascal) ; 6] Ω (ohm) ; 7] L (litre) ; 8] t (tonne) ; 9] ha (hectare) ; 10] Å (ångström) ; 11] mL (millilitre) ; 12] cm (centimetre) ; 13] dB (decibel) ; 14] kbit (kilobit) ; 15] Kibit (kibibit) ; 16] kB (kilobyte) ; 17] KiB (kibibyte) ; 18] MB (megabyte) ; 19] MiB (mebibyte) </a:documentation>
+Suggested values include: 1] m (metre); 2] kg (kilogram); 3] s (second); 4] Hz (hertz); 5] Pa (pascal); 6] Ω (ohm); 7] L (litre); 8] t (tonne); 9] ha (hectare); 10] Å (ångström); 11] mL (millilitre); 12] cm (centimetre); 13] dB (decibel); 14] kbit (kilobit); 15] Kibit (kibibit); 16] kB (kilobyte); 17] KiB (kibibyte); 18] MB (megabyte); 19] MiB (mebibyte)</a:documentation>
         <choice>
           <value>m</value>
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(metre) SI base unit of length</a:documentation>
@@ -3216,7 +3216,7 @@ Suggested values include: 1] volume; 2] issue; 3] page; 4] line; 5] chapter; 6] 
     <optional>
       <attribute name="extent">
         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether the pronunciation or orthography applies to all or part of a word.
-Suggested values include: 1] full (full form) ; 2] pref (prefix) ; 3] suff (suffix) ; 4] inf (infix) ; 5] part (partial) </a:documentation>
+Suggested values include: 1] full (full form); 2] pref (prefix); 3] suff (suffix); 4] inf (infix); 5] part (partial)</a:documentation>
         <choice>
           <value>full</value>
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(full form) </a:documentation>
@@ -4533,7 +4533,7 @@ Elements]</a:documentation>
       <optional>
         <attribute name="type">
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">classifies the title according to some convenient typology.
-Sample values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) </a:documentation>
+Sample values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)</a:documentation>
           <data type="token">
             <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
           </data>
@@ -5880,7 +5880,7 @@ Sample values include: 1] first-line; 2] first-letter; 3] before; 4] after</a:do
       <optional>
         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="datum" a:defaultValue="WGS84">
           <a:documentation>supplies a commonly used code name for the datum employed.
-Suggested values include: 1] WGS84 (World Geodetic System) ; 2] MGRS (Military Grid Reference System) ; 3] OSGB36 (ordnance survey great britain) ; 4] ED50 (European Datum coordinate system) </a:documentation>
+Suggested values include: 1] WGS84 (World Geodetic System); 2] MGRS (Military Grid Reference System); 3] OSGB36 (ordnance survey great britain); 4] ED50 (European Datum coordinate system)</a:documentation>
           <choice>
             <value>WGS84</value>
             <a:documentation>(World Geodetic System) a pair of numbers to be interpreted as latitude followed by longitude according to the World Geodetic System.</a:documentation>
@@ -6644,7 +6644,7 @@ The @spanTo attribute of <name/> is required.</assert>
       <optional>
         <attribute name="type">
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">classifies the material encoded according to some useful typology.
-Sample values include: 1] header; 2] footer; 3] pageNum (page number) ; 4] lineNum (line number) ; 5] sig (signature) ; 6] catch (catchword) </a:documentation>
+Sample values include: 1] header; 2] footer; 3] pageNum (page number); 4] lineNum (line number); 5] sig (signature); 6] catch (catchword)</a:documentation>
           <data type="token">
             <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
           </data>
@@ -8446,7 +8446,7 @@ Suggested values include: 1] initial; 2] final</a:documentation>
       <optional>
         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="type" a:defaultValue="main">
           <a:documentation>specifies the role of this subdivision of the title.
-Suggested values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) </a:documentation>
+Suggested values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)</a:documentation>
           <choice>
             <value>main</value>
             <a:documentation>main title of the work</a:documentation>
@@ -8832,7 +8832,7 @@ Suggested values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4
       <optional>
         <attribute name="unit">
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the unit of time in which the interval value is expressed, if this is not inherited from the parent timeline.
-Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) </a:documentation>
+Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)</a:documentation>
           <choice>
             <value>d</value>
             <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(days) </a:documentation>
@@ -8891,7 +8891,7 @@ Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (
       <optional>
         <attribute name="unit">
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the unit of time corresponding to the interval value of the timeline or of its constituent points in time.
-Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) </a:documentation>
+Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)</a:documentation>
           <choice>
             <value>d</value>
             <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(days) </a:documentation>
@@ -9078,7 +9078,7 @@ You must supply at least two values for @target on <name/>
     <optional>
       <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="type" a:defaultValue="main">
         <a:documentation>indicates type of entry, in dictionaries with multiple types.
-Suggested values include: 1] main; 2] hom (homograph) ; 3] xref (cross reference) ; 4] affix; 5] abbr (abbreviation) ; 6] supplemental; 7] foreign</a:documentation>
+Suggested values include: 1] main; 2] hom (homograph); 3] xref (cross reference); 4] affix; 5] abbr (abbreviation); 6] supplemental; 7] foreign</a:documentation>
         <choice>
           <value>main</value>
           <a:documentation>a main entry (default).</a:documentation>
@@ -9627,7 +9627,7 @@ Suggested values include: 1] simple; 2] lemma; 3] variant; 4] compound; 5] deriv
       <optional>
         <attribute name="type">
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">classifies the grammatical information given according to some convenient typology—in the case of terminological information, preferably the dictionary of data element types specified in ISO 12620.
-Sample values include: 1] pos (part of speech) ; 2] gen (gender) ; 3] num (number) ; 4] animate; 5] proper</a:documentation>
+Sample values include: 1] pos (part of speech); 2] gen (gender); 3] num (number); 4] animate; 5] proper</a:documentation>
           <data type="token">
             <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
           </data>
@@ -9806,7 +9806,7 @@ Sample values include: 1] abbrev; 2] verbTable</a:documentation>
       <optional>
         <attribute name="type">
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">classifies the usage information using any convenient typology.
-Sample values include: 1] geo (geographic) ; 2] time; 3] dom (domain) ; 4] register; 5] style; 6] plev (preference level) ; 7] lang (language) ; 8] gram (grammatical) ; 9] syn (synonym) ; 10] hyper (hypernym) ; 11] colloc (collocation) ; 12] comp (complement) ; 13] obj (object) ; 14] subj (subject) ; 15] verb; 16] hint</a:documentation>
+Sample values include: 1] geo (geographic); 2] time; 3] dom (domain); 4] register; 5] style; 6] plev (preference level); 7] lang (language); 8] gram (grammatical); 9] syn (synonym); 10] hyper (hypernym); 11] colloc (collocation); 12] comp (complement); 13] obj (object); 14] subj (subject); 15] verb; 16] hint</a:documentation>
           <data type="token">
             <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
           </data>
@@ -9851,7 +9851,7 @@ Sample values include: 1] geo (geographic) ; 2] time; 3] dom (domain) ; 4] regis
       <optional>
         <attribute name="type">
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the type of cross reference, using any convenient typology.
-Sample values include: 1] syn (synonym) ; 2] etym (etymological) ; 3] cf (compare or consult) ; 4] illus (illustration) </a:documentation>
+Sample values include: 1] syn (synonym); 2] etym (etymological); 3] cf (compare or consult); 4] illus (illustration)</a:documentation>
           <data type="token">
             <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
           </data>
@@ -9896,7 +9896,7 @@ Sample values include: 1] syn (synonym) ; 2] etym (etymological) ; 3] cf (compar
       <optional>
         <attribute name="type">
           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the kind of typographic modification made to the headword in the reference.
-Sample values include: 1] cap (capital) ; 2] noHyph (no hyphen) </a:documentation>
+Sample values include: 1] cap (capital); 2] noHyph (no hyphen)</a:documentation>
           <data type="token">
             <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
           </data>

--- a/Test/expected-results/test15.odd.html
+++ b/Test/expected-results/test15.odd.html
@@ -338,7 +338,7 @@
                   <span lang="es" class="label" itemprop="hi">Ejemplo</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <div id="index.xml-egXML-d33e957" class="pre egXML_valid"><span class="element">&lt;body&gt;</span>
+                  <div id="index.xml-egXML-d33e952" class="pre egXML_valid"><span class="element">&lt;body&gt;</span>
  <span class="element">&lt;div <span class="attribute">typ</span>="<span class="attributevalue">part</span>"&gt;</span>
   <span class="element">&lt;head&gt;</span>Fallacies of Authority<span class="element">&lt;/head&gt;</span>
   <span class="element">&lt;para&gt;</span>The subject of which is Authority in various shapes, and the object, to repress all
@@ -698,7 +698,7 @@ element div
                   <span lang="es" class="label" itemprop="hi">Ejemplo</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <div id="index.xml-egXML-d33e1769" class="pre egXML_valid"><span class="element">&lt;para&gt;</span>Hallgerd was outside. <span class="element">&lt;q&gt;</span>There is blood on your axe,<span class="element">&lt;/q&gt;</span> she said. <span class="element">&lt;q&gt;</span>What have you
+                  <div id="index.xml-egXML-d33e1764" class="pre egXML_valid"><span class="element">&lt;para&gt;</span>Hallgerd was outside. <span class="element">&lt;q&gt;</span>There is blood on your axe,<span class="element">&lt;/q&gt;</span> she said. <span class="element">&lt;q&gt;</span>What have you
    done?<span class="element">&lt;/q&gt;</span>
 <span class="element">&lt;/para&gt;</span>
 <span class="element">&lt;para&gt;</span>
@@ -1042,7 +1042,7 @@ element para
                   <span lang="es" class="label" itemprop="hi">Ejemplo</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <div id="index.xml-egXML-d33e2774" class="pre egXML_valid">It is spelled <span class="element">&lt;q&gt;</span>Tübingen<span class="element">&lt;/q&gt;</span> — to enter the
+                  <div id="index.xml-egXML-d33e2767" class="pre egXML_valid">It is spelled <span class="element">&lt;q&gt;</span>Tübingen<span class="element">&lt;/q&gt;</span> — to enter the
  letter <span class="element">&lt;q&gt;</span>u<span class="element">&lt;/q&gt;</span> with an umlaut hold down the <span class="element">&lt;q&gt;</span>option<span class="element">&lt;/q&gt;</span> key and press 
 <span class="element">&lt;q&gt;</span>0 0 f c<span class="element">&lt;/q&gt;</span></div>
                 </td>

--- a/Test/expected-results/test15.odd.rnc
+++ b/Test/expected-results/test15.odd.rnc
@@ -112,7 +112,7 @@ att.dimensions.attributes =
 att.dimensions.attribute.unit =
   
   ## names the unit used for the measurement
-  ## Suggested values include: 1] cm (centimetres) ; 2] mm (millimetres) ; 3] in (inches) ; 4] lines; 5] chars (characters) 
+  ## Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inches); 4] lines; 5] chars (characters)
   attribute unit {
     
     ## (centimetres) 
@@ -675,7 +675,7 @@ att.measurement.attributes =
 att.measurement.attribute.unit =
   
   ## indicates the units used for the measurement, usually using the standard symbol for the desired units.
-  ## Suggested values include: 1] m (metre) ; 2] kg (kilogram) ; 3] s (second) ; 4] Hz (hertz) ; 5] Pa (pascal) ; 6] Ω (ohm) ; 7] L (litre) ; 8] t (tonne) ; 9] ha (hectare) ; 10] Å (ångström) ; 11] mL (millilitre) ; 12] cm (centimetre) ; 13] dB (decibel) ; 14] kbit (kilobit) ; 15] Kibit (kibibit) ; 16] kB (kilobyte) ; 17] KiB (kibibyte) ; 18] MB (megabyte) ; 19] MiB (mebibyte) 
+  ## Suggested values include: 1] m (metre); 2] kg (kilogram); 3] s (second); 4] Hz (hertz); 5] Pa (pascal); 6] Ω (ohm); 7] L (litre); 8] t (tonne); 9] ha (hectare); 10] Å (ångström); 11] mL (millilitre); 12] cm (centimetre); 13] dB (decibel); 14] kbit (kilobit); 15] Kibit (kibibit); 16] kB (kilobyte); 17] KiB (kibibyte); 18] MB (megabyte); 19] MiB (mebibyte)
   attribute unit {
     
     ## (metre) SI base unit of length
@@ -2585,7 +2585,7 @@ title =
     att.datable.attributes,
     
     ## classifies the title according to some convenient typology.
-    ## Sample values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Sample values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -3584,7 +3584,7 @@ geoDecl =
     att.declarable.attributes,
     
     ## supplies a commonly used code name for the datum employed.
-    ## Suggested values include: 1] WGS84 (World Geodetic System) ; 2] MGRS (Military Grid Reference System) ; 3] OSGB36 (ordnance survey great britain) ; 4] ED50 (European Datum coordinate system) 
+    ## Suggested values include: 1] WGS84 (World Geodetic System); 2] MGRS (Military Grid Reference System); 3] OSGB36 (ordnance survey great britain); 4] ED50 (European Datum coordinate system)
     [ a:defaultValue = "WGS84" ]
     attribute datum {
       
@@ -4214,7 +4214,7 @@ titlePart =
     att.global.attributes,
     
     ## specifies the role of this subdivision of the title.
-    ## Suggested values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Suggested values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     [ a:defaultValue = "main" ]
     attribute type {
       
@@ -4503,7 +4503,7 @@ when =
     }?,
     
     ## specifies the unit of time in which the interval value is expressed, if this is not inherited from the parent timeline.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 
@@ -4552,7 +4552,7 @@ timeline =
     attribute origin { xsd:anyURI }?,
     
     ## specifies the unit of time corresponding to the interval value of the timeline or of its constituent points in time.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 

--- a/Test/expected-results/test21.odd.rnc
+++ b/Test/expected-results/test21.odd.rnc
@@ -113,7 +113,7 @@ att.dimensions.attributes =
 att.dimensions.attribute.unit =
   
   ## noms des unités utilisées pour la mesure.
-  ## Suggested values include: 1] cm (centimetres) ; 2] mm (millimetres) ; 3] in (inches) ; 4] lines; 5] chars (characters) 
+  ## Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inches); 4] lines; 5] chars (characters)
   attribute unit {
     
     ## (centimètres) 
@@ -128,7 +128,7 @@ att.dimensions.attribute.unit =
       ## lignes de texte
       "lines"
     | 
-      ##  (characters) caractères du texte
+      ## (characters) caractères du texte
       "chars"
     | xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
   }?
@@ -425,19 +425,19 @@ att.fragmentable.attribute.part =
   [ a:defaultValue = "N" ]
   attribute part {
     
-    ##  (yes) the element is fragmented in some (unspecified) respect
+    ## (yes) the element is fragmented in some (unspecified) respect
     "Y"
     | 
-      ##  (no) the element is not fragmented, or no claim is made as to its completeness
+      ## (no) the element is not fragmented, or no claim is made as to its completeness
       "N"
     | 
-      ##  (initial) this is the initial part of a fragmented element
+      ## (initial) this is the initial part of a fragmented element
       "I"
     | 
-      ##  (medial) this is a medial part of a fragmented element
+      ## (medial) this is a medial part of a fragmented element
       "M"
     | 
-      ##  (final) this is the final part of a fragmented element
+      ## (final) this is the final part of a fragmented element
       "F"
   }?
 att.divLike.attributes =
@@ -717,7 +717,7 @@ att.measurement.attributes =
 att.measurement.attribute.unit =
   
   ## (unité) indique les unités de mesure utilisées ; il s'agit en général du symbole normalisé pour les unités dont on a besoin.
-  ## Suggested values include: 1] m (metre) ; 2] kg (kilogram) ; 3] s (second) ; 4] Hz (hertz) ; 5] Pa (pascal) ; 6] Ω (ohm) ; 7] L (litre) ; 8] t (tonne) ; 9] ha (hectare) ; 10] Å (ångström) ; 11] mL (millilitre) ; 12] cm (centimetre) ; 13] dB (decibel) ; 14] kbit (kilobit) ; 15] Kibit (kibibit) ; 16] kB (kilobyte) ; 17] KiB (kibibyte) ; 18] MB (megabyte) ; 19] MiB (mebibyte) 
+  ## Suggested values include: 1] m (metre); 2] kg (kilogram); 3] s (second); 4] Hz (hertz); 5] Pa (pascal); 6] Ω (ohm); 7] L (litre); 8] t (tonne); 9] ha (hectare); 10] Å (ångström); 11] mL (millilitre); 12] cm (centimetre); 13] dB (decibel); 14] kbit (kilobit); 15] Kibit (kibibit); 16] kB (kilobyte); 17] KiB (kibibyte); 18] MB (megabyte); 19] MiB (mebibyte)
   attribute unit {
     
     ## (mètre) unité SI (système international) de longueur
@@ -729,28 +729,28 @@ att.measurement.attribute.unit =
       ## (seconde) unité SI de temps
       "s"
     | 
-      ##  (hertz) unité SI de fréquence
+      ## (hertz) unité SI de fréquence
       "Hz"
     | 
-      ##  (pascal) unité SI de pression
+      ## (pascal) unité SI de pression
       "Pa"
     | 
-      ##  (ohm) unité SI de résistance électrique
+      ## (ohm) unité SI de résistance électrique
       "Ω"
     | 
-      ##  (litre) 1 dm³
+      ## (litre) 1 dm³
       "L"
     | 
-      ##  (tonne) 10³ kg
+      ## (tonne) 10³ kg
       "t"
     | 
-      ##  (hectare) 1 hm²
+      ## (hectare) 1 hm²
       "ha"
     | 
-      ##  (ångström) 10⁻¹⁰ m
+      ## (ångström) 10⁻¹⁰ m
       "Å"
     | 
-      ##  (millilitre) 
+      ## (millilitre) 
       "mL"
     | 
       ## (centimètre) 
@@ -759,10 +759,10 @@ att.measurement.attribute.unit =
       ## (décibel) Voir remarques, ci-dessous.
       "dB"
     | 
-      ##  (kilobit) 10³ ou 1000 bits
+      ## (kilobit) 10³ ou 1000 bits
       "kbit"
     | 
-      ##  (kibibit) 2¹⁰ ou 1024 bits
+      ## (kibibit) 2¹⁰ ou 1024 bits
       "Kibit"
     | 
       ## (kilo-octet) 10³ ou 1000 octets
@@ -1006,7 +1006,7 @@ att.edition.attribute.ed =
   }?
 att.edition.attribute.edRef =
   
-  ##  (edition reference) provides a pointer to the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.
+  ## (edition reference) provides a pointer to the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.
   attribute edRef {
     list { xsd:anyURI+ }
   }?
@@ -2286,7 +2286,7 @@ sic =
   element sic { macro.paraContent, att.global.attributes, empty }
 corr =
   
-  ##  (correction) contient la forme correcte d'un passage qui est considéré erroné dans la copie du texte. [3.4.1. Apparent Errors]
+  ## (correction) contient la forme correcte d'un passage qui est considéré erroné dans la copie du texte. [3.4.1. Apparent Errors]
   element corr {
     macro.paraContent,
     att.global.attributes,
@@ -2876,7 +2876,7 @@ milestone =
   }
 gb =
   
-  ##  (gathering beginning) marks the beginning of a new gathering or quire in a transcribed codex. [3.10.3. Milestone
+  ## (gathering beginning) marks the beginning of a new gathering or quire in a transcribed codex. [3.10.3. Milestone
   ## Elements]
   element gb {
     empty,
@@ -3055,13 +3055,13 @@ title =
         ## (monographique) titre de monographie (livre, ensemble ou autre, publié comme un document distinct, y compris les volumes isolés d'ouvrages en plusieurs volumes)
         "m"
       | 
-        ##  (journal) titre de revue
+        ## (journal) titre de revue
         "j"
       | 
         ## (série) titre de publication en série
         "s"
       | 
-        ##  (unpublished) titre de matéria non publié (thèses et dissertations comprises, à l'exception de leurs éditions commerciales)
+        ## (unpublished) titre de matéria non publié (thèses et dissertations comprises, à l'exception de leurs éditions commerciales)
         "u"
     }?,
     empty
@@ -3101,7 +3101,7 @@ biblScope =
   }
 citedRange =
   
-  ##  (cited range) defines the range of cited content, often represented by pages or other units [3.11.2.5. Scopes and Ranges in Bibliographic Citations]
+  ## (cited range) defines the range of cited content, often represented by pages or other units [3.11.2.5. Scopes and Ranges in Bibliographic Citations]
   element citedRange {
     macro.phraseSeq,
     att.global.attributes,
@@ -3815,7 +3815,7 @@ age =
     att.dimensions.attributes,
     
     ## caractérise l'élément en utilisant n'importe quel système ou typologie de classification approprié.
-    ## Sample values include: 1] western; 2] sui; 3] subjective; 4] objective; 5] inWorld (in world) ; 6] chronological; 7] biological; 8] psychological; 9] functional
+    ## Sample values include: 1] western; 2] sui; 3] subjective; 4] objective; 5] inWorld (in world); 6] chronological; 7] biological; 8] psychological; 9] functional
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -3837,7 +3837,7 @@ birth =
     att.typed.attribute.subtype,
     
     ## caractérise l'élément en utilisant n'importe quel système ou typologie de classification approprié.
-    ## Sample values include: 1] caesarean (caesarean section) ; 2] vaginal (vaginal delivery) ; 3] exNihilo (ex nihilo) ; 4] incorporated; 5] founded; 6] established
+    ## Sample values include: 1] caesarean (caesarean section); 2] vaginal (vaginal delivery); 3] exNihilo (ex nihilo); 4] incorporated; 5] founded; 6] established
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -4474,7 +4474,7 @@ trait =
   }
 objectName =
   
-  ##  (name of an object) contains a proper noun or noun phrase used to refer to an object. [13.2.4. Object Names]
+  ## (name of an object) contains a proper noun or noun phrase used to refer to an object. [13.2.4. Object Names]
   element objectName {
     macro.phraseSeq,
     att.datable.attributes,
@@ -4503,7 +4503,7 @@ object =
   }
 listObject =
   
-  ##  (list of objects) contains a list of descriptions, each of which provides information about an identifiable physical object. [13.3.5. Objects]
+  ## (list of objects) contains a list of descriptions, each of which provides information about an identifiable physical object. [13.3.5. Objects]
   element listObject {
     (model.headLike*, model.objectLike+, (relation | listRelation)*),
     att.global.attributes,
@@ -4514,7 +4514,7 @@ listObject =
   }
 objectIdentifier =
   
-  ##  (object identifier) groups one or more identifiers or pieces of locating information concerning a single object. [13.3.5. Objects]
+  ## (object identifier) groups one or more identifiers or pieces of locating information concerning a single object. [13.3.5. Objects]
   element objectIdentifier {
     ((model.placeNamePart
       | institution
@@ -4806,7 +4806,7 @@ encodingDesc =
   }
 schemaRef =
   
-  ##  (schema reference) describes or points to a related customization or schema file [2.3.9. The Schema Specification]
+  ## (schema reference) describes or points to a related customization or schema file [2.3.9. The Schema Specification]
   element schemaRef {
     model.descLike?,
     att.global.attributes,
@@ -5087,7 +5087,7 @@ rendition =
   }
 styleDefDecl =
   
-  ##  (style definition language declaration) specifies the name of the formal language in which style or renditional information is supplied elsewhere in the document. The specific version of the scheme may also be supplied. [2.3.5. The Default Style Definition Language Declaration]
+  ## (style definition language declaration) specifies the name of the formal language in which style or renditional information is supplied elsewhere in the document. The specific version of the scheme may also be supplied. [2.3.5. The Default Style Definition Language Declaration]
   element styleDefDecl {
     model.pLike*,
     att.global.attributes,
@@ -5115,7 +5115,7 @@ cRefPattern =
   }
 prefixDef =
   
-  ##  (prefix definition) defines a prefixing scheme used in data.pointer values, showing how abbreviated URIs using the scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]
+  ## (prefix definition) defines a prefixing scheme used in data.pointer values, showing how abbreviated URIs using the scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]
   element prefixDef {
     model.pLike*,
     att.global.attributes,
@@ -5129,7 +5129,7 @@ prefixDef =
   }
 listPrefixDef =
   
-  ##  (list of prefix definitions) contains a list of definitions of prefixing schemes used in data.pointer values, showing how abbreviated URIs using each scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]
+  ## (list of prefix definitions) contains a list of definitions of prefixing schemes used in data.pointer values, showing how abbreviated URIs using each scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]
   element listPrefixDef {
     (prefixDef | listPrefixDef)+, att.global.attributes, empty
   }
@@ -5189,7 +5189,7 @@ geoDecl =
     att.declarable.attributes,
     
     ## donne un nom de code d'usage général pour les données employées.
-    ## Suggested values include: 1] WGS84 (World Geodetic System) ; 2] MGRS (Military Grid Reference System) ; 3] OSGB36 (ordnance survey great britain) ; 4] ED50 (European Datum coordinate system) 
+    ## Suggested values include: 1] WGS84 (World Geodetic System); 2] MGRS (Military Grid Reference System); 3] OSGB36 (ordnance survey great britain); 4] ED50 (European Datum coordinate system)
     [ a:defaultValue = "WGS84" ]
     attribute datum {
       
@@ -5348,7 +5348,7 @@ calendar =
   }
 correspDesc =
   
-  ##  (correspondence
+  ## (correspondence
   ##     description) contains a description of the actions related to one act of correspondence. [2.4.6. Correspondence Description]
   element correspDesc {
     (model.correspDescPart+ | model.pLike+),
@@ -5360,7 +5360,7 @@ correspDesc =
   }
 correspAction =
   
-  ##  (correspondence action) contains a structured description of the place, the name of a person/organization and the date related to the sending/receiving of a message or any other action related to the correspondence. [2.4.6. Correspondence Description]
+  ## (correspondence action) contains a structured description of the place, the name of a person/organization and the date related to the sending/receiving of a message or any other action related to the correspondence. [2.4.6. Correspondence Description]
   element correspAction {
     (model.correspActionPart+ | model.pLike+),
     att.global.attributes,
@@ -5391,13 +5391,13 @@ correspAction =
   }
 correspContext =
   
-  ##  (correspondence context) provides references to preceding or following correspondence related to this piece of correspondence. [2.4.6. Correspondence Description]
+  ## (correspondence context) provides references to preceding or following correspondence related to this piece of correspondence. [2.4.6. Correspondence Description]
   element correspContext {
     model.correspContextPart+, att.global.attributes, empty
   }
 xenoData =
   
-  ##  (non-TEI metadata) provides a container element into which metadata in non-TEI formats may be placed. [2.5. Non-TEI Metadata]
+  ## (non-TEI metadata) provides a container element into which metadata in non-TEI formats may be placed. [2.5. Non-TEI Metadata]
   element xenoData {
     (text | anyElement-xenoData),
     att.global.attributes,
@@ -5655,7 +5655,7 @@ when =
     }?,
     
     ## spécifie l'unité de temps dans laquelle la valeur de l'attribut interval est exprimée, si elle n'est pas héritée de l'élément parent timeLine.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (jours) 
@@ -5664,7 +5664,7 @@ when =
         ## (heures) 
         "h"
       | 
-        ##  (minutes) 
+        ## (minutes) 
         "min"
       | 
         ## (secondes) 
@@ -5704,7 +5704,7 @@ timeline =
     attribute origin { xsd:anyURI }?,
     
     ## spécifie l'unité de temps correspondant à la valeur de l'attribut interval de la frise chronologique ou des points temporels qui la constituent.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (jours) 
@@ -5713,7 +5713,7 @@ timeline =
         ## (heures) 
         "h"
       | 
-        ##  (minutes) 
+        ## (minutes) 
         "min"
       | 
         ## (secondes) 
@@ -6405,7 +6405,7 @@ supportDesc =
     att.global.attributes,
     
     ## (matériau) contient un nom abrégé propre au projet désignant le matériau qui a principalement servi pour fabriquer le support.
-    ## Suggested values include: 1] paper; 2] parch (parchment) ; 3] mixed
+    ## Suggested values include: 1] paper; 2] parch (parchment); 3] mixed
     attribute material {
       
       ##
@@ -6456,7 +6456,7 @@ layout =
       list { xsd:nonNegativeInteger, xsd:nonNegativeInteger? }
     }?,
     
-    ##  (textual streams) indicates the number of streams per page, each of which contains an independent textual stream
+    ## (textual streams) indicates the number of streams per page, each of which contains an independent textual stream
     attribute streams {
       list { xsd:nonNegativeInteger, xsd:nonNegativeInteger? }
     }?,
@@ -7140,7 +7140,7 @@ fw =
     att.written.attributes,
     
     ## caractérise l'information encodée conformément à une typologie appropriée.
-    ## Sample values include: 1] header; 2] footer; 3] pageNum (page number) ; 4] lineNum (line number) ; 5] sig (signature) ; 6] catch (catchword) 
+    ## Sample values include: 1] header; 2] footer; 3] pageNum (page number); 4] lineNum (line number); 5] sig (signature); 6] catch (catchword)
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -7297,7 +7297,7 @@ surplus =
   }
 secl =
   
-  ##  (secluded text) Secluded. Marks text present in the source which the editor believes to be genuine but out of its original place (which is unknown). [11.3.1.7. Text Omitted from or Supplied in the Transcription]
+  ## (secluded text) Secluded. Marks text present in the source which the editor believes to be genuine but out of its original place (which is unknown). [11.3.1.7. Text Omitted from or Supplied in the Transcription]
   element secl {
     macro.paraContent,
     att.global.attributes,
@@ -7735,7 +7735,7 @@ salute =
   }
 signed =
   
-  ##  (signature) contient la dernière salutation, ajoutée à un avant-propos, à une dédicace ou à une autre division du texte. [4.2.2. Openers and Closers]
+  ## (signature) contient la dernière salutation, ajoutée à un avant-propos, à une dédicace ou à une autre division du texte. [4.2.2. Openers and Closers]
   element signed {
     macro.paraContent,
     att.global.attributes,
@@ -7786,7 +7786,7 @@ titlePart =
     att.global.attributes,
     
     ## précise le rôle de cette subdivision du titre.
-    ## Suggested values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Suggested values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     [ a:defaultValue = "main" ]
     attribute type {
       

--- a/Test/expected-results/test30.rnc
+++ b/Test/expected-results/test30.rnc
@@ -115,7 +115,7 @@ Tatt.dimensions.attributes =
 Tatt.dimensions.attribute.unit =
   
   ## names the unit used for the measurement
-  ## Suggested values include: 1] cm (centimetres) ; 2] mm (millimetres) ; 3] in (inches) ; 4] lines; 5] chars (characters) 
+  ## Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inches); 4] lines; 5] chars (characters)
   attribute unit {
     
     ## (centimetres) 
@@ -696,7 +696,7 @@ Tatt.measurement.attributes =
 Tatt.measurement.attribute.unit =
   
   ## indicates the units used for the measurement, usually using the standard symbol for the desired units.
-  ## Suggested values include: 1] m (metre) ; 2] kg (kilogram) ; 3] s (second) ; 4] Hz (hertz) ; 5] Pa (pascal) ; 6] Ω (ohm) ; 7] L (litre) ; 8] t (tonne) ; 9] ha (hectare) ; 10] Å (ångström) ; 11] mL (millilitre) ; 12] cm (centimetre) ; 13] dB (decibel) ; 14] kbit (kilobit) ; 15] Kibit (kibibit) ; 16] kB (kilobyte) ; 17] KiB (kibibyte) ; 18] MB (megabyte) ; 19] MiB (mebibyte) 
+  ## Suggested values include: 1] m (metre); 2] kg (kilogram); 3] s (second); 4] Hz (hertz); 5] Pa (pascal); 6] Ω (ohm); 7] L (litre); 8] t (tonne); 9] ha (hectare); 10] Å (ångström); 11] mL (millilitre); 12] cm (centimetre); 13] dB (decibel); 14] kbit (kilobit); 15] Kibit (kibibit); 16] kB (kilobyte); 17] KiB (kibibyte); 18] MB (megabyte); 19] MiB (mebibyte)
   attribute unit {
     
     ## (metre) SI base unit of length
@@ -3993,7 +3993,7 @@ TgeoDecl =
     Tatt.declarable.attributes,
     
     ## supplies a commonly used code name for the datum employed.
-    ## Suggested values include: 1] WGS84 (World Geodetic System) ; 2] MGRS (Military Grid Reference System) ; 3] OSGB36 (ordnance survey great britain) ; 4] ED50 (European Datum coordinate system) 
+    ## Suggested values include: 1] WGS84 (World Geodetic System); 2] MGRS (Military Grid Reference System); 3] OSGB36 (ordnance survey great britain); 4] ED50 (European Datum coordinate system)
     [ a:defaultValue = "WGS84" ]
     attribute datum {
       
@@ -4612,7 +4612,7 @@ Tage =
     Tatt.dimensions.attributes,
     
     ## characterizes the element in some sense, using any convenient classification scheme or typology.
-    ## Sample values include: 1] western; 2] sui; 3] subjective; 4] objective; 5] inWorld (in world) ; 6] chronological; 7] biological; 8] psychological; 9] functional
+    ## Sample values include: 1] western; 2] sui; 3] subjective; 4] objective; 5] inWorld (in world); 6] chronological; 7] biological; 8] psychological; 9] functional
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -4634,7 +4634,7 @@ Tbirth =
     Tatt.typed.attribute.subtype,
     
     ## characterizes the element in some sense, using any convenient classification scheme or typology.
-    ## Sample values include: 1] caesarean (caesarean section) ; 2] vaginal (vaginal delivery) ; 3] exNihilo (ex nihilo) ; 4] incorporated; 5] founded; 6] established
+    ## Sample values include: 1] caesarean (caesarean section); 2] vaginal (vaginal delivery); 3] exNihilo (ex nihilo); 4] incorporated; 5] founded; 6] established
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -5769,7 +5769,7 @@ Tfw =
     Tatt.written.attributes,
     
     ## classifies the material encoded according to some useful typology.
-    ## Sample values include: 1] header; 2] footer; 3] pageNum (page number) ; 4] lineNum (line number) ; 5] sig (signature) ; 6] catch (catchword) 
+    ## Sample values include: 1] header; 2] footer; 3] pageNum (page number); 4] lineNum (line number); 5] sig (signature); 6] catch (catchword)
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -6277,7 +6277,7 @@ Twhen =
     }?,
     
     ## specifies the unit of time in which the interval value is expressed, if this is not inherited from the parent timeline.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 
@@ -6326,7 +6326,7 @@ Ttimeline =
     attribute origin { xsd:anyURI }?,
     
     ## specifies the unit of time corresponding to the interval value of the timeline or of its constituent points in time.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 
@@ -6765,7 +6765,7 @@ TtitlePart =
     Tatt.global.attributes,
     
     ## specifies the role of this subdivision of the title.
-    ## Suggested values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Suggested values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     [ a:defaultValue = "main" ]
     attribute type {
       

--- a/Test/expected-results/test33.json
+++ b/Test/expected-results/test33.json
@@ -56,11 +56,11 @@
         [  ],
         "classes" : 
         { "model" : 
-          [  ],
+          [ "model.quoteLike" ],
           "atts" : 
           [  ],
           "unknown" : 
-          [ "model.quoteLike" ] },
+          [  ] },
         "attributes" : 
         [ 
           { "onElement" : true,

--- a/Test/expected-results/test33.rnc
+++ b/Test/expected-results/test33.rnc
@@ -121,7 +121,7 @@ tei_att.dimensions.attributes =
 tei_att.dimensions.attribute.unit =
   
   ## names the unit used for the measurement
-  ## Suggested values include: 1] cm (centimetres) ; 2] mm (millimetres) ; 3] in (inches) ; 4] lines; 5] chars (characters) 
+  ## Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inches); 4] lines; 5] chars (characters)
   attribute unit {
     
     ## (centimetres) 
@@ -687,7 +687,7 @@ tei_att.measurement.attributes =
 tei_att.measurement.attribute.unit =
   
   ## indicates the units used for the measurement, usually using the standard symbol for the desired units.
-  ## Suggested values include: 1] m (metre) ; 2] kg (kilogram) ; 3] s (second) ; 4] Hz (hertz) ; 5] Pa (pascal) ; 6] Ω (ohm) ; 7] L (litre) ; 8] t (tonne) ; 9] ha (hectare) ; 10] Å (ångström) ; 11] mL (millilitre) ; 12] cm (centimetre) ; 13] dB (decibel) ; 14] kbit (kilobit) ; 15] Kibit (kibibit) ; 16] kB (kilobyte) ; 17] KiB (kibibyte) ; 18] MB (megabyte) ; 19] MiB (mebibyte) 
+  ## Suggested values include: 1] m (metre); 2] kg (kilogram); 3] s (second); 4] Hz (hertz); 5] Pa (pascal); 6] Ω (ohm); 7] L (litre); 8] t (tonne); 9] ha (hectare); 10] Å (ångström); 11] mL (millilitre); 12] cm (centimetre); 13] dB (decibel); 14] kbit (kilobit); 15] Kibit (kibibit); 16] kB (kilobyte); 17] KiB (kibibyte); 18] MB (megabyte); 19] MiB (mebibyte)
   attribute unit {
     
     ## (metre) SI base unit of length
@@ -2743,7 +2743,7 @@ tei_title =
     tei_att.datable.attributes,
     
     ## classifies the title according to some convenient typology.
-    ## Sample values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Sample values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -3779,7 +3779,7 @@ tei_geoDecl =
     tei_att.declarable.attributes,
     
     ## supplies a commonly used code name for the datum employed.
-    ## Suggested values include: 1] WGS84 (World Geodetic System) ; 2] MGRS (Military Grid Reference System) ; 3] OSGB36 (ordnance survey great britain) ; 4] ED50 (European Datum coordinate system) 
+    ## Suggested values include: 1] WGS84 (World Geodetic System); 2] MGRS (Military Grid Reference System); 3] OSGB36 (ordnance survey great britain); 4] ED50 (European Datum coordinate system)
     [ a:defaultValue = "WGS84" ]
     attribute datum {
       
@@ -4432,7 +4432,7 @@ tei_titlePart =
     tei_att.global.attributes,
     
     ## specifies the role of this subdivision of the title.
-    ## Suggested values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Suggested values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     [ a:defaultValue = "main" ]
     attribute type {
       
@@ -4730,7 +4730,7 @@ tei_when =
     }?,
     
     ## specifies the unit of time in which the interval value is expressed, if this is not inherited from the parent timeline.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 
@@ -4779,7 +4779,7 @@ tei_timeline =
     attribute origin { xsd:anyURI }?,
     
     ## specifies the unit of time corresponding to the interval value of the timeline or of its constituent points in time.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 

--- a/Test/expected-results/test34.combined.json
+++ b/Test/expected-results/test34.combined.json
@@ -182,7 +182,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "open",
               "valItem" : 
               [ 
                 { "ident" : "suspension",
@@ -452,7 +452,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "excl",
@@ -537,7 +537,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "excl",
@@ -901,7 +901,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "free",
@@ -2195,7 +2195,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "high",
@@ -2254,7 +2254,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "silent",
@@ -2321,7 +2321,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "sent",
@@ -2495,6 +2495,7 @@
             "model.publicationStmtPart.detail" ],
           "atts" : 
           [ "att.global",
+            "att.canonical",
             "att.datable",
             "att.editLike",
             "att.dimensions",
@@ -2595,8 +2596,8 @@
         "type" : "elementSpec",
         "module" : "core",
         "desc" : 
-        [ "<desc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2016-09-25\" xml:lang=\"en\">contains a brief description of the object documented by its parent element, typically a documentation\n    element or an entity.<\/desc>" ],
-        "shortDesc" : "(description) contains a brief description of the object documented by its parent element, typically a documentation\n    element or an entity.",
+        [ "<desc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2016-09-25\" xml:lang=\"en\">contains a brief\n  description of the object documented by its parent element,\n  typically a documentation element or an entity.<\/desc>" ],
+        "shortDesc" : "(description) contains a brief\n  description of the object documented by its parent element,\n  typically a documentation element or an entity.",
         "gloss" : 
         [ "<gloss xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2005-01-14\" xml:lang=\"en\">description<\/gloss>" ],
         "altIdent" : 
@@ -2612,7 +2613,35 @@
           "unknown" : 
           [  ] },
         "attributes" : 
-        [  ],
+        [ 
+          { "onElement" : true,
+            "ident" : "type",
+            "mode" : "change",
+            "ns" : "",
+            "usage" : "def",
+            "desc" : 
+            [  ],
+            "shortDesc" : "",
+            "gloss" : 
+            [  ],
+            "altIdent" : 
+            [  ],
+            "valDesc" : 
+            [  ],
+            "datatype" : 
+            {  },
+            "valList" : 
+            { "type" : "semi",
+              "valItem" : 
+              [ 
+                { "ident" : "deprecationInfo",
+                  "desc" : 
+                  [ "<desc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2018-09-14\" xml:lang=\"en\">This element\n\t  describes why or how its parent element is being deprecated,\n\t  typically including recommendations for alternate\n\t  encoding.<\/desc>" ],
+                  "shortDesc" : "(deprecation\n\t  information) This element\n\t  describes why or how its parent element is being deprecated,\n\t  typically including recommendations for alternate\n\t  encoding.",
+                  "gloss" : 
+                  [ "<gloss xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2018-09-14\" xml:lang=\"en\">deprecation\n\t  information<\/gloss>" ],
+                  "altIdent" : 
+                  [  ] } ] } } ],
         "content" : 
         [ 
           { "type" : "macroRef",
@@ -3671,7 +3700,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "open",
               "valItem" : 
               [ 
                 { "ident" : "index",
@@ -4534,7 +4563,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "cancelled",
@@ -4620,7 +4649,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "open",
               "valItem" : 
               [ 
                 { "ident" : "rubbing",
@@ -4731,7 +4760,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "WGS84",
@@ -5101,7 +5130,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "all",
@@ -5188,7 +5217,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "ISBN",
@@ -5520,7 +5549,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "root",
@@ -6080,7 +6109,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "gloss",
@@ -6864,7 +6893,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "silent",
@@ -7034,7 +7063,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "cardinal",
@@ -7086,7 +7115,9 @@
             "altIdent" : 
             [  ],
             "valDesc" : 
-            [ "<valDesc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\">a numeric value.<\/valDesc>" ],
+            [ "<valDesc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\">a numeric value.<\/valDesc>",
+              "<valDesc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" xml:lang=\"fr\">une valeur numérique.<\/valDesc>",
+              "<valDesc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" xml:lang=\"de\">ein numerischer Wert<\/valDesc>" ],
             "datatype" : 
             { "min" : "1",
               "max" : "1",
@@ -7635,7 +7666,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "none",
@@ -7685,7 +7716,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "internal",
@@ -7751,7 +7782,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "spoken",
@@ -7908,7 +7939,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "none",
@@ -8223,7 +8254,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "open",
               "valItem" : 
               [ 
                 { "ident" : "first-line",
@@ -9088,7 +9119,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "setting",
@@ -9903,7 +9934,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "d",
@@ -10018,7 +10049,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "closed",
               "valItem" : 
               [ 
                 { "ident" : "a",
@@ -10086,7 +10117,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "open",
               "valItem" : 
               [ 
                 { "ident" : "main",
@@ -10242,7 +10273,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "main",
@@ -10418,7 +10449,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "illegible",
@@ -10486,7 +10517,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "open",
               "valItem" : 
               [ 
                 { "ident" : "rubbing",
@@ -10607,7 +10638,7 @@
               "dataRef" : 
               { "key" : "teidata.enumerated" } },
             "valList" : 
-            { "type" : "",
+            { "type" : "semi",
               "valItem" : 
               [ 
                 { "ident" : "d",
@@ -12362,7 +12393,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "semi",
                 "valItem" : 
                 [ 
                   { "ident" : "volume",
@@ -12736,7 +12767,7 @@
                 "dataRef" : 
                 { "key" : "teidata.truthValue" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "closed",
                 "valItem" : 
                 [ 
                   { "ident" : "true",
@@ -12830,7 +12861,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "semi",
                 "valItem" : 
                 [ 
                   { "ident" : "cm",
@@ -12958,7 +12989,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "open",
                 "valItem" : 
                 [ 
                   { "ident" : "all",
@@ -13028,7 +13059,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "closed",
                 "valItem" : 
                 [ 
                   { "ident" : "composite",
@@ -13069,7 +13100,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "closed",
                 "valItem" : 
                 [ 
                   { "ident" : "initial",
@@ -13150,7 +13181,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "open",
                 "valItem" : 
                 [ 
                   { "ident" : "approved",
@@ -13321,7 +13352,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "semi",
                 "valItem" : 
                 [ 
                   { "ident" : "internal",
@@ -13457,7 +13488,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "closed",
                 "valItem" : 
                 [ 
                   { "ident" : "Y",
@@ -13628,7 +13659,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "closed",
                 "valItem" : 
                 [ 
                   { "ident" : "default",
@@ -14128,7 +14159,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "closed",
                 "valItem" : 
                 [ 
                   { "ident" : "sole",
@@ -14224,7 +14255,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "semi",
                 "valItem" : 
                 [ 
                   { "ident" : "m",
@@ -14551,7 +14582,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "semi",
                 "valItem" : 
                 [ 
                   { "ident" : "page",
@@ -14857,7 +14888,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "closed",
                 "valItem" : 
                 [ 
                   { "ident" : "yes",
@@ -14940,7 +14971,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "semi",
                 "valItem" : 
                 [ 
                   { "ident" : "below",
@@ -15106,7 +15137,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "closed",
                 "valItem" : 
                 [ 
                   { "ident" : "all",
@@ -15483,7 +15514,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "closed",
                 "valItem" : 
                 [ 
                   { "ident" : "css",
@@ -15643,7 +15674,7 @@
                 "dataRef" : 
                 { "key" : "teidata.enumerated" } },
               "valList" : 
-              { "type" : "",
+              { "type" : "open",
                 "valItem" : 
                 [ 
                   { "ident" : "duplicate",
@@ -16435,8 +16466,8 @@
         "type" : "dataSpec",
         "module" : "tei",
         "desc" : 
-        [ "<desc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2013-04-14\" xml:lang=\"en\">defines attribute values which contain an XPath  expression.<\/desc>" ],
-        "shortDesc" : "defines attribute values which contain an XPath  expression.",
+        [ "<desc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2013-04-14\" xml:lang=\"en\">defines attribute values\nwhich contain an XPath expression.<\/desc>" ],
+        "shortDesc" : "defines attribute values\nwhich contain an XPath expression.",
         "gloss" : 
         [  ],
         "altIdent" : 

--- a/Test/expected-results/test34.json
+++ b/Test/expected-results/test34.json
@@ -56,11 +56,11 @@
         [  ],
         "classes" : 
         { "model" : 
-          [  ],
+          [ "model.quoteLike" ],
           "atts" : 
           [  ],
           "unknown" : 
-          [ "model.quoteLike" ] },
+          [  ] },
         "attributes" : 
         [  ],
         "content" : 
@@ -84,11 +84,11 @@
         [  ],
         "classes" : 
         { "model" : 
-          [  ],
+          [ "model.quoteLike" ],
           "atts" : 
           [  ],
           "unknown" : 
-          [ "model.quoteLike" ] },
+          [  ] },
         "attributes" : 
         [  ],
         "content" : 
@@ -112,11 +112,11 @@
         [  ],
         "classes" : 
         { "model" : 
-          [  ],
+          [ "model.quoteLike" ],
           "atts" : 
           [  ],
           "unknown" : 
-          [ "model.quoteLike" ] },
+          [  ] },
         "attributes" : 
         [  ],
         "content" : 

--- a/Test/expected-results/test34.rnc
+++ b/Test/expected-results/test34.rnc
@@ -122,7 +122,7 @@ tei_att.dimensions.attributes =
 tei_att.dimensions.attribute.unit =
   
   ## names the unit used for the measurement
-  ## Suggested values include: 1] cm (centimetres) ; 2] mm (millimetres) ; 3] in (inches) ; 4] lines; 5] chars (characters) 
+  ## Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inches); 4] lines; 5] chars (characters)
   attribute unit {
     
     ## (centimetres) 
@@ -688,7 +688,7 @@ tei_att.measurement.attributes =
 tei_att.measurement.attribute.unit =
   
   ## indicates the units used for the measurement, usually using the standard symbol for the desired units.
-  ## Suggested values include: 1] m (metre) ; 2] kg (kilogram) ; 3] s (second) ; 4] Hz (hertz) ; 5] Pa (pascal) ; 6] Ω (ohm) ; 7] L (litre) ; 8] t (tonne) ; 9] ha (hectare) ; 10] Å (ångström) ; 11] mL (millilitre) ; 12] cm (centimetre) ; 13] dB (decibel) ; 14] kbit (kilobit) ; 15] Kibit (kibibit) ; 16] kB (kilobyte) ; 17] KiB (kibibyte) ; 18] MB (megabyte) ; 19] MiB (mebibyte) 
+  ## Suggested values include: 1] m (metre); 2] kg (kilogram); 3] s (second); 4] Hz (hertz); 5] Pa (pascal); 6] Ω (ohm); 7] L (litre); 8] t (tonne); 9] ha (hectare); 10] Å (ångström); 11] mL (millilitre); 12] cm (centimetre); 13] dB (decibel); 14] kbit (kilobit); 15] Kibit (kibibit); 16] kB (kilobyte); 17] KiB (kibibyte); 18] MB (megabyte); 19] MiB (mebibyte)
   attribute unit {
     
     ## (metre) SI base unit of length
@@ -2748,7 +2748,7 @@ tei_title =
     tei_att.datable.attributes,
     
     ## classifies the title according to some convenient typology.
-    ## Sample values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Sample values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -3782,7 +3782,7 @@ tei_geoDecl =
     tei_att.declarable.attributes,
     
     ## supplies a commonly used code name for the datum employed.
-    ## Suggested values include: 1] WGS84 (World Geodetic System) ; 2] MGRS (Military Grid Reference System) ; 3] OSGB36 (ordnance survey great britain) ; 4] ED50 (European Datum coordinate system) 
+    ## Suggested values include: 1] WGS84 (World Geodetic System); 2] MGRS (Military Grid Reference System); 3] OSGB36 (ordnance survey great britain); 4] ED50 (European Datum coordinate system)
     [ a:defaultValue = "WGS84" ]
     attribute datum {
       
@@ -4435,7 +4435,7 @@ tei_titlePart =
     tei_att.global.attributes,
     
     ## specifies the role of this subdivision of the title.
-    ## Suggested values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Suggested values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     [ a:defaultValue = "main" ]
     attribute type {
       
@@ -4733,7 +4733,7 @@ tei_when =
     }?,
     
     ## specifies the unit of time in which the interval value is expressed, if this is not inherited from the parent timeline.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 
@@ -4782,7 +4782,7 @@ tei_timeline =
     attribute origin { xsd:anyURI }?,
     
     ## specifies the unit of time corresponding to the interval value of the timeline or of its constituent points in time.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 

--- a/Test/expected-results/test35.rnc
+++ b/Test/expected-results/test35.rnc
@@ -120,7 +120,7 @@ tei_att.dimensions.attributes =
 tei_att.dimensions.attribute.unit =
   
   ## names the unit used for the measurement
-  ## Suggested values include: 1] cm (centimetres) ; 2] mm (millimetres) ; 3] in (inches) ; 4] lines; 5] chars (characters) 
+  ## Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inches); 4] lines; 5] chars (characters)
   attribute unit {
     
     ## (centimetres) 
@@ -686,7 +686,7 @@ tei_att.measurement.attributes =
 tei_att.measurement.attribute.unit =
   
   ## indicates the units used for the measurement, usually using the standard symbol for the desired units.
-  ## Suggested values include: 1] m (metre) ; 2] kg (kilogram) ; 3] s (second) ; 4] Hz (hertz) ; 5] Pa (pascal) ; 6] Ω (ohm) ; 7] L (litre) ; 8] t (tonne) ; 9] ha (hectare) ; 10] Å (ångström) ; 11] mL (millilitre) ; 12] cm (centimetre) ; 13] dB (decibel) ; 14] kbit (kilobit) ; 15] Kibit (kibibit) ; 16] kB (kilobyte) ; 17] KiB (kibibyte) ; 18] MB (megabyte) ; 19] MiB (mebibyte) 
+  ## Suggested values include: 1] m (metre); 2] kg (kilogram); 3] s (second); 4] Hz (hertz); 5] Pa (pascal); 6] Ω (ohm); 7] L (litre); 8] t (tonne); 9] ha (hectare); 10] Å (ångström); 11] mL (millilitre); 12] cm (centimetre); 13] dB (decibel); 14] kbit (kilobit); 15] Kibit (kibibit); 16] kB (kilobyte); 17] KiB (kibibyte); 18] MB (megabyte); 19] MiB (mebibyte)
   attribute unit {
     
     ## (metre) SI base unit of length
@@ -2742,7 +2742,7 @@ tei_title =
     tei_att.datable.attributes,
     
     ## classifies the title according to some convenient typology.
-    ## Sample values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Sample values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     attribute type {
       xsd:token { pattern = "(\p{L}|\p{N}|\p{P}|\p{S})+" }
     }?,
@@ -3762,7 +3762,7 @@ tei_geoDecl =
     tei_att.declarable.attributes,
     
     ## supplies a commonly used code name for the datum employed.
-    ## Suggested values include: 1] WGS84 (World Geodetic System) ; 2] MGRS (Military Grid Reference System) ; 3] OSGB36 (ordnance survey great britain) ; 4] ED50 (European Datum coordinate system) 
+    ## Suggested values include: 1] WGS84 (World Geodetic System); 2] MGRS (Military Grid Reference System); 3] OSGB36 (ordnance survey great britain); 4] ED50 (European Datum coordinate system)
     [ a:defaultValue = "WGS84" ]
     attribute datum {
       
@@ -4415,7 +4415,7 @@ tei_titlePart =
     tei_att.global.attributes,
     
     ## specifies the role of this subdivision of the title.
-    ## Suggested values include: 1] main; 2] sub (subordinate) ; 3] alt (alternate) ; 4] short; 5] desc (descriptive) 
+    ## Suggested values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] short; 5] desc (descriptive)
     [ a:defaultValue = "main" ]
     attribute type {
       
@@ -4713,7 +4713,7 @@ tei_when =
     }?,
     
     ## specifies the unit of time in which the interval value is expressed, if this is not inherited from the parent timeline.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 
@@ -4762,7 +4762,7 @@ tei_timeline =
     attribute origin { xsd:anyURI }?,
     
     ## specifies the unit of time corresponding to the interval value of the timeline or of its constituent points in time.
-    ## Suggested values include: 1] d (days) ; 2] h (hours) ; 3] min (minutes) ; 4] s (seconds) ; 5] ms (milliseconds) 
+    ## Suggested values include: 1] d (days); 2] h (hours); 3] min (minutes); 4] s (seconds); 5] ms (milliseconds)
     attribute unit {
       
       ## (days) 

--- a/Test/expected-results/testdrama.compiled.xml
+++ b/Test/expected-results/testdrama.compiled.xml
@@ -15,7 +15,7 @@
    </teiHeader>
 <text>
 <body>
-    <schemaSpec xmlns:teix="http://www.tei-c.org/ns/Examples" ident="testdrama" start="TEI" defaultExceptions="http://www.tei-c.org/ns/1.0 teix:egXML" source="http://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml"><classSpec module="tei" type="atts" ident="att.ascribed">
+    <schemaSpec xmlns:teix="http://www.tei-c.org/ns/Examples" ident="testdrama" start="TEI" defaultExceptions="http://www.tei-c.org/ns/1.0 teix:egXML" source="https://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml"><classSpec module="tei" type="atts" ident="att.ascribed">
   <desc versionDate="2006-01-05" xml:lang="en">provides attributes for elements representing speech or action that can be ascribed to a
     specific individual.</desc>
   <desc versionDate="2007-12-20" xml:lang="ko">특정 개인의 대화 또는 행위를 표시하는 요소에 대한 속성을 제공한다.</desc>

--- a/bin/transformtei
+++ b/bin/transformtei
@@ -83,6 +83,7 @@ verbose=false
 summaryDoc=""
 antflag="-q -Djava.awt.headless=true"
 TEISOURCE=
+TEISOURCE_DEFAULT=https://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml
 
 # epub only
 overlayfile=
@@ -175,15 +176,15 @@ fi
 # for the source as set in the XSL Stylesheets
 if test "x$TEISOURCE" = "x"
 then
-  localsource=""
-  echo "WARNING: No localsource set. Will get a copy from http://www.tei-c.org/Vault/P5/ when necessary."
+  defaultSource="\"$TEISOURCE_DEFAULT\""
+  echo "WARNING: No localsource set. Will get a copy from $TEISOURCE_DEFAULT if necessary."
 
 # case 2: localsource is set and starts with 'http',
 # thus pointing at a remote resource
 elif [ "$TEISOURCE" != "${TEISOURCE#http}" ]
 then
-  echo using remote resource $TEISOURCE as default source 
-  localsource=" -DdefaultSource=\"$TEISOURCE\" "
+  echo "using remote resource $TEISOURCE as default source" 
+  defaultSource="\"$TEISOURCE\""
 
 # case 3: localsource is set and the local file exists
 elif test -e $TEISOURCE
@@ -191,8 +192,9 @@ then
   REALD=`dirname "$TEISOURCE"`
   SDIR=`(cd $REALD; pwd)`
   REALSOURCE=$SDIR/`basename $TEISOURCE`
-  echo using local file $REALSOURCE as default source
-  localsource=" -DdefaultSource=\"$REALSOURCE\" "
+  echo "using local file $REALSOURCE as default source"
+  defaultSource="\"$REALSOURCE\""
+# last case: exit with error
 else 
   die "unable to get localsource from $TEISOURCE"
 fi
@@ -235,7 +237,7 @@ esac
 echo Convert $infile to $outdir/$outfile \($from to $to\) using profile $profile $debug $fileperpage $splitLevel $viewportwidth $viewportheight 
 ant $antflag -f "$APPHOME/$format/build-$direction.xml" \
 	-lib "${SAXONJAR}" $debug \
-    $fileperpage $cssFile $splitLevel $viewportwidth $viewportheight $summaryDoc $mediaoverlay $nocompress $localsource \
+    $fileperpage $cssFile $splitLevel $viewportwidth $viewportheight $summaryDoc $mediaoverlay $nocompress \
         -Dodd=$odd \
         -Dsaxon.jar="${SAXONJAR}" \
         -Dtrang.jar="${TRANGJAR}" \
@@ -250,6 +252,7 @@ ant $antflag -f "$APPHOME/$format/build-$direction.xml" \
 	-Dlang=$lang \
 	-Dsubject=$subject \
 	-Dcoverimage=$cover \
-	-Doxygenlib=$oxygenlib
+	-Doxygenlib=$oxygenlib \
+	-DdefaultSource=$defaultSource
 
 	

--- a/bin/transformtei
+++ b/bin/transformtei
@@ -171,11 +171,11 @@ then
   localsource=""
   echo "WARNING: No localsource set. Will get a copy from http://www.tei-c.org/Vault/P5/."
 else 
-  REALD=`dirname "$TEISOURCE"`
-  SDIR=`(cd $REALD; pwd)`
-  REALSOURCE=$SDIR/`basename $TEISOURCE`
-  echo using $REALSOURCE as default source
-  localsource=" -DdefaultSource=\"$REALSOURCE\" "
+#  REALD=`dirname "$TEISOURCE"`
+#  SDIR=`(cd $REALD; pwd)`
+#  REALSOURCE=$SDIR/`basename $TEISOURCE`
+  echo using $TEISOURCE as default source
+  localsource=" -DdefaultSource=\"$TEISOURCE\" "
 fi
 
 in=${1:?"no input file supplied; for usage syntax $0 --help"}

--- a/bin/transformtei
+++ b/bin/transformtei
@@ -166,16 +166,35 @@ then
 	profiledir=$APPHOME/profiles
     fi
 fi
+
+# **************************************** #
+# *** work out defaultSource parameter *** # 
+# ***  to pass to the XSL Stylesheets  *** #
+# **************************************** #  
+# case 1: no localsource set, we'll use the hard-coded values 
+# for the source as set in the XSL Stylesheets
 if test "x$TEISOURCE" = "x"
 then
   localsource=""
-  echo "WARNING: No localsource set. Will get a copy from http://www.tei-c.org/Vault/P5/."
-else 
-#  REALD=`dirname "$TEISOURCE"`
-#  SDIR=`(cd $REALD; pwd)`
-#  REALSOURCE=$SDIR/`basename $TEISOURCE`
-  echo using $TEISOURCE as default source
+  echo "WARNING: No localsource set. Will get a copy from http://www.tei-c.org/Vault/P5/ when necessary."
+
+# case 2: localsource is set and starts with 'http',
+# thus pointing at a remote resource
+elif [ "$TEISOURCE" != "${TEISOURCE#http}" ]
+then
+  echo using remote resource $TEISOURCE as default source 
   localsource=" -DdefaultSource=\"$TEISOURCE\" "
+
+# case 3: localsource is set and the local file exists
+elif test -e $TEISOURCE
+then
+  REALD=`dirname "$TEISOURCE"`
+  SDIR=`(cd $REALD; pwd)`
+  REALSOURCE=$SDIR/`basename $TEISOURCE`
+  echo using local file $REALSOURCE as default source
+  localsource=" -DdefaultSource=\"$REALSOURCE\" "
+else 
+  die "unable to get localsource from $TEISOURCE"
 fi
 
 in=${1:?"no input file supplied; for usage syntax $0 --help"}

--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -1202,7 +1202,7 @@ of this software, even if advised of the possibility of such damage.
                                     if ($gloss ne '') then '&#x20;' else '',
                                     $gloss,
                                     if (following-sibling::tei:valItem) then ';' else '',
-                                    '&#x20;'
+                                    if (position() ne last()) then '&#x20;' else ''
                                     )"/>
           </xsl:for-each>
         </xsl:when>

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -59,7 +59,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:param name="configDirectory"/>
   <xsl:param name="currentDirectory"/>
   <xsl:param name="defaultSource"/>
-  <xsl:param name="defaultTEIServer">http://www.tei-c.org/Vault/P5/</xsl:param>
+  <xsl:param name="defaultTEIServer">https://www.tei-c.org/Vault/P5/</xsl:param>
   <xsl:param name="defaultTEIVersion">current</xsl:param>
   <xsl:param name="doclang"/>
   <xsl:param name="selectedSchema"/>

--- a/tools/getnames.xsl
+++ b/tools/getnames.xsl
@@ -37,12 +37,14 @@ theory of liability, whether in contract, strict liability, or tort
 of this software, even if advised of the possibility of such damage.
 
 -->
+  
+  <xsl:param name="defaultSource" select="'https://www.tei-c.org/release/xml/tei/odd/p5subset.xml'"/>
 
   <xsl:template name="main">
     <elementList>
       <xsl:for-each
-	  select="doc('http://www.tei-c.org/release/xml/tei/odd/p5subset.xml')//elementSpec">
-	<gi><xsl:value-of select="@ident"/></gi>
+        select="doc($defaultSource)//elementSpec">
+        <gi><xsl:value-of select="@ident"/></gi>
       </xsl:for-each>
     </elementList>
   </xsl:template>

--- a/tools/oddbyexample.xsl
+++ b/tools/oddbyexample.xsl
@@ -88,7 +88,7 @@ valList
   <xsl:param name="includeHeader">true</xsl:param>
   <!-- the source of the TEI (just needs *Spec)-->
   <xsl:param name="defaultSource"
-    >http://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml</xsl:param>
+    >https://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml</xsl:param>
   <!-- should we make valList for @rend and @rendition -->
   <xsl:param name="enumerateRend">false</xsl:param>
   <!-- should we make valList for @type -->


### PR DESCRIPTION
This PR fixes the current build process issue due to http->http redirects for http://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml. 

Rather than changing all calls in the respective stylesheets I tried to improve the build process by adding and propagating a `DEFAULTSOURCE` parameter, so finally it's possible to run the tests against a local source of your choice! 

There were several changes needed:

* `tools/getnames.xsl`: replace hard coded value with a parameter that can be overwritten from outside
* `bin/transformtei`: support remote resource for `--localsource` parameter
* `Makefile` and `Test/Makefile`: add defaultSource parameter per default to every call to saxon, and add the `--localsource` parameter per default to every call to `/$(BINDIR)/teitoXXX` 
* some updates to the expected results as aftermath of #357 
* and well, this does not belong here, but when diffing the tests with the expected results I found an extra trailing whitespace from #357 which is removed now in `common/functions.xsl` 