### PR TITLE
make sure to only pass one prefix to `concat()`, fixes 366

### DIFF
--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -1311,7 +1311,7 @@ of this software, even if advised of the possibility of such damage.
             * Note that $myns will be undefined both when the ancestor
             * <elementSpec> does not have an @ns, and when there is no
             * ancestor <elementSpec>. *-->
-        <xsl:when test="not($myns)  or  $myns='http://www.tei-c.org/ns/1.0'">
+        <xsl:when test="not($myns)  or  $myns eq 'http://www.tei-c.org/ns/1.0'">
           <xsl:text>tei:</xsl:text>
         </xsl:when>
         <!--* otherwise, if an ancestor has a suitable <sch:ns> element, 

--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -1298,29 +1298,56 @@ of this software, even if advised of the possibility of such damage.
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
     <desc>which prefix for schematron</desc>
   </doc>
-
+  <!--* tei:generate-nsprefix-schematron($e)
+      * Calculate a namespace prefix for a given element, or fail. *-->
   <xsl:function name="tei:generate-nsprefix-schematron" as="xs:string">
-    <xsl:param name="e"/>
+    <xsl:param name="e" as="element()"/>
     <xsl:for-each select="$e">
-      <xsl:variable name="myns" select="ancestor::tei:elementSpec/@ns"/>
+      <xsl:variable name="myns" select="normalize-space( ancestor::tei:elementSpec/@ns )"/>
+      <xsl:variable name="prefixes" select="in-scope-prefixes(.)" as="xs:string*"/>
+      <xsl:variable name="uris" select="for $pre in $prefixes return namespace-uri-for-prefix( $pre,$e)" as="xs:anyURI*"/>
       <xsl:choose>
-        <xsl:when test="not($myns) or $myns='http://www.tei-c.org/ns/1.0'">
+        <!--* if ns is not specified or is tei, use 'tei'
+            * Note that $myns will be undefined both when the ancestor
+            * <elementSpec> does not have an @ns, and when there is no
+            * ancestor <elementSpec>. *-->
+        <xsl:when test="not($myns)  or  $myns='http://www.tei-c.org/ns/1.0'">
           <xsl:text>tei:</xsl:text>
         </xsl:when>
+        <!--* otherwise, if an ancestor has a suitable <sch:ns> element, 
+            * use the one belonging to the nearest such ancestor *-->
+        <xsl:when test="ancestor::*/sch:ns[ normalize-space(@uri) eq $myns ]">
+          <xsl:variable name="a" as="element()"
+                        select="ancestor::*[sch:ns[ normalize-space(@uri) eq $myns ]][1]"/>
+          <xsl:variable name="prefix" as="xs:string*"
+                        select="$a/sch:ns[ normalize-space(@uri) eq $myns ]/normalize-space(@prefix)"/>
+          <xsl:value-of select="concat( $prefix[1],':')"/>
+        </xsl:when>
+        <!--* Otherwise, if the actual declaration has a suitable
+            * namespace node, use the current prefix. Or, to be
+            * exact, any one of the current non-null prefixes.
+            * We'll take the first one presented.
+            *-->
+        <xsl:when test="$uris = $myns  and  $myns ne ''">
+          <xsl:variable name="indx" select="index-of( $uris, $myns )[1]"/>
+          <xsl:value-of select="concat( $prefixes[$indx],':')"/>
+        </xsl:when>
+        <!--* If no ancestor has a suitable sch:ns child, and we don't
+            * have any local namespace bindings with non-zero
+            * prefixes, then we are desperate and we will take any 
+            * sch:ns in the schemaSpec (this is getting a bit desperate) *-->   
+        <xsl:when test="ancestor::tei:schemaSpec//sch:ns[ normalize-space(@uri) eq $myns ]">
+          <xsl:variable name="NSs" select="ancestor::tei:schemaSpec//sch:ns[ normalize-space(@uri) eq $myns ]"/>
+          <xsl:value-of select="concat($NSs[1]/normalize-space(@prefix),':')"/>
+        </xsl:when>
         <xsl:otherwise>
-          <xsl:choose>
-            <xsl:when test="ancestor::tei:schemaSpec//sch:ns[@uri=$myns]">
-              <xsl:value-of
-                  select="concat((ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix)[1],':')"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:message terminate="yes">schematron rule cannot work out prefix for <xsl:value-of select="ancestor::tei:elementSpec/@ident"/></xsl:message>
-            </xsl:otherwise>
-          </xsl:choose>
+          <xsl:message terminate="yes"
+                       select="concat('schematron rule cannot work out prefix for ', ancestor::tei:elementSpec/@ident, '.')"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
   </xsl:function>
+
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
     <desc>find version of stylesheets</desc>

--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -1311,7 +1311,7 @@ of this software, even if advised of the possibility of such damage.
           <xsl:choose>
             <xsl:when test="ancestor::tei:schemaSpec//sch:ns[@uri=$myns]">
               <xsl:value-of
-                  select="concat(ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix,':')"/>
+                  select="concat((ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix)[1],':')"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:message terminate="yes">schematron rule cannot work out prefix for <xsl:value-of select="ancestor::tei:elementSpec/@ident"/></xsl:message>

--- a/odds/extract-sch.xsl
+++ b/odds/extract-sch.xsl
@@ -161,7 +161,7 @@ of this software, even if advised of the possibility of such damage.
 	  <xsl:choose>
 	    <xsl:when test="ancestor::tei:schemaSpec//sch:ns[@uri=$myns]">
 	      <xsl:value-of
-		  select="concat(ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix,':')"/>
+		  select="concat((ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix)[1],':')"/>
 	    </xsl:when>
 	    <xsl:otherwise>
 	      <xsl:message terminate="yes">schematron rule cannot work out prefix for <xsl:value-of select="ancestor::tei:elementSpec/@ident"/></xsl:message>

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -287,29 +287,6 @@ of this software, even if advised of the possibility of such damage.
     </xsl:for-each>
   </xsl:function>
 
-  <xsl:function name="tei:generate-nsprefix-schematron" as="xs:string">
-    <xsl:param name="e"/>
-    <xsl:for-each select="$e">
-      <xsl:variable name="myns" select="ancestor::tei:elementSpec/@ns"/>
-      <xsl:choose>
-        <xsl:when test="not($myns) or $myns='http://www.tei-c.org/ns/1.0'">
-          <xsl:text>tei:</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:choose>
-            <xsl:when test="ancestor::tei:schemaSpec//sch:ns[@uri=$myns]">
-              <xsl:value-of
-                  select="concat((ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix)[1],':')"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:message terminate="yes">schematron rule cannot work out prefix for <xsl:value-of select="ancestor::tei:elementSpec/@ident"/></xsl:message>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:for-each>
-  </xsl:function>
-
   <xsl:template name="die">
     <xsl:param name="message"/>
     <xsl:message terminate="yes">

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -299,7 +299,7 @@ of this software, even if advised of the possibility of such damage.
           <xsl:choose>
             <xsl:when test="ancestor::tei:schemaSpec//sch:ns[@uri=$myns]">
               <xsl:value-of
-                  select="concat(ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix,':')"/>
+                  select="concat((ancestor::tei:schemaSpec//sch:ns[@uri=$myns]/@prefix)[1],':')"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:message terminate="yes">schematron rule cannot work out prefix for <xsl:value-of select="ancestor::tei:elementSpec/@ident"/></xsl:message>


### PR DESCRIPTION
that originated from https://github.com/TEIC/Roma/issues/26

While it looks like a simple fix, I'm not 150% sure about the implications, so feedback from @sydb who's done more work on Schematron is highly appreciated.

Also, @cmsmcq has a local fix for the issue at hand. Maybe he can add to that as well?