### PR TITLE
Improve error handling for faulty moduleRef uri

### DIFF
--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -1233,19 +1233,34 @@ select="$makeDecls"/></xsl:message>
               <xsl:comment>Start of import of <xsl:value-of select="@url"/>
               </xsl:comment>
               <div xmlns="http://relaxng.org/ns/structure/1.0">
-                <xsl:for-each select="doc(resolve-uri(@url,$BASE))/rng:grammar">
-                  <!-- the "expandRNG" processing changed 2011-08-25 by Syd Bauman: -->
-                  <!-- added a 'prefix' parameter which value is prefixed to pattern -->
-                  <!-- names in the included schema. This prevents collisions in the -->
-                  <!-- output RNG. -->
-                  <xsl:apply-templates mode="expandRNG" select="@*|node()">
-                    <xsl:with-param name="prefix">
-		      <xsl:if test="$me-the-moduleRef/@prefix">
-			<xsl:value-of select="$me-the-moduleRef/@prefix"/>
-		      </xsl:if>
-                    </xsl:with-param>
-                  </xsl:apply-templates>
-                </xsl:for-each>
+                <xsl:choose>
+                  <xsl:when test="doc-available(resolve-uri(@url,$BASE))">
+                    <xsl:for-each select="doc(resolve-uri(@url,$BASE))/rng:grammar">
+                      <!-- the "expandRNG" processing changed 2011-08-25 by Syd Bauman: -->
+                      <!-- added a 'prefix' parameter which value is prefixed to pattern -->
+                      <!-- names in the included schema. This prevents collisions in the -->
+                      <!-- output RNG. -->
+                      <xsl:apply-templates mode="expandRNG" select="@*|node()">
+                        <xsl:with-param name="prefix">
+                          <xsl:if test="$me-the-moduleRef/@prefix">
+                            <xsl:value-of select="$me-the-moduleRef/@prefix"/>
+                          </xsl:if>
+                        </xsl:with-param>
+                      </xsl:apply-templates>
+                    </xsl:for-each>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:message terminate="yes">
+                      <xsl:text>Document not available: </xsl:text>
+                      <xsl:value-of select="@url"/>
+                    </xsl:message>
+                    <!--
+                    <xsl:call-template name="die">
+                      <xsl:with-param name="message" select="concat('Document not available: ', @url)"/>
+                    </xsl:call-template>
+                    -->
+                  </xsl:otherwise>
+                </xsl:choose>
                 <xsl:apply-templates mode="justcopy"  select="tei:content/*"/>
               </div>
               <xsl:comment>End of import of <xsl:value-of select="@url"/>

--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -1254,11 +1254,6 @@ select="$makeDecls"/></xsl:message>
                       <xsl:text>Document not available: </xsl:text>
                       <xsl:value-of select="@url"/>
                     </xsl:message>
-                    <!--
-                    <xsl:call-template name="die">
-                      <xsl:with-param name="message" select="concat('Document not available: ', @url)"/>
-                    </xsl:call-template>
-                    -->
                   </xsl:otherwise>
                 </xsl:choose>
                 <xsl:apply-templates mode="justcopy"  select="tei:content/*"/>


### PR DESCRIPTION
This PR intends to communicate the cause of failure more clearly in cases where external modules are referenced and the resource is not available/parseable during conversion.

We found this with @textloop when trying to include

```xml
<moduleRef url="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/mathml2-main.rng"/>
```
which is now (after the February incident?) forwarded to https.

**Error message before this change:**

```
System ID: /Volumes/WORKBENCH/gitlab/testing/schema/tei_hal.odd
Scenario: TEI ODD to RELAX NG XML - Copy
Build file: /Applications/oXygen XML/oxygen 21.0/frameworks/tei/xml/tei/stylesheet/relaxng/build-to.xml
Engine name: ANT
Severity: fatal
Description: Transformation failed. /Applications/oXygen XML/oxygen 21.0/frameworks/tei/xml/tei/stylesheet/common/teianttasks.xml:356: ; SystemID: file:/Applications/oXygen%20XML/oxygen%2021.0/frameworks/tei/xml/tei/stylesheet/odds/teiodds.xsl; Line#: 1238; Column#: 20
```
```
     [xslt] start importing moduleRef components
     [xslt]  .... import module [http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/mathml2-main.rng] 
     [xslt] http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/mathml2-main.rng:6:3: Fatal Error! Error reported by XML parser Cause: org.xml.sax.SAXParseException; systemId: http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/mathml2-main.rng; lineNumber: 6; columnNumber: 3; The element type "hr" must be terminated by the matching end-tag "</hr>".
     [xslt] Failed to process /Volumes/WORKBENCH/gitlab/testing/schema/tei_hal.odd.processedodd
```

**Error message after this change:**

```
System ID: /Volumes/WORKBENCH/gitlab/testing/schema/tei_hal.odd
Scenario: TEI ODD to RELAX NG XML - Copy
Build file: /Applications/oXygen XML/oxygen 21.0/frameworks/tei/xml/tei/stylesheet/relaxng/build-to.xml
Engine name: ANT
Severity: fatal
Description: Transformation failed. Fatal error during transformation using /Applications/oXygen XML/oxygen 21.0/frameworks/tei/xml/tei/stylesheet/profiles/default/relaxng/to.xsl: Processing terminated by xsl:message at line 1255 in teiodds.xsl; SystemID: file:/Applications/oXygen%20XML/oxygen%2021.0/frameworks/tei/xml/tei/stylesheet/odds/teiodds.xsl; Line#: 1255; Column#: 4
```
```
     [xslt] start importing moduleRef components
     [xslt]  .... import module [http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/mathml2-main.rng] 
     [xslt] Document not available: http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/mathml2-main.rng
     [xslt] /Applications/oXygen XML/oxygen 21.0/frameworks/tei/xml/tei/stylesheet/odds/teiodds.xsl:1255:4: Fatal Error! Processing terminated by xsl:message at line 1255 in teiodds.xsl
     [xslt] Failed to process /Volumes/WORKBENCH/gitlab/testing/schema/tei_hal.odd.processedodd
```

It would also be possible to call the (otherwise unused) `die` template, but getting the right line number immediately in the error message seems preferable.