### PR TITLE
improved processing of "quotation elements" and footnotes w.r.t. subs…

### DIFF
--- a/profiles/jtei/jtei.common.xsl
+++ b/profiles/jtei/jtei.common.xsl
@@ -84,10 +84,47 @@
     </xsl:if>
   </xsl:template>
   
-  <!-- This template pulls subsequent punctuation into generated quotation 
-    marks. -->
+  <!-- This template pulls subsequent punctuation into generated quotation, or before a 
+       footnote marker. -->
   <xsl:template name="include.punctuation">
-    <xsl:value-of select="following-sibling::node()[not(self::tei:note)][1]/self::text()[matches(., '^\s*[\p{P}-[:;\p{Ps}\p{Pe}—]]')]/replace(., '^\s*([\p{P}-[\p{Ps}\p{Pe}]]+).*', '$1', 's')"/>
+    <xsl:choose>
+      <!-- quotation elements: only place following comma and period before the closing quotation mark -->
+      <!-- condition: the element should not end in a nesting "pulling punctuation quotes" context, 
+           since subsequent punctuation should be pulled inside the innermost quotation marks.
+      -->
+      <xsl:when test="
+        not(self::tei:note) 
+        and
+        not(
+          some $text in descendant::text()[normalize-space()][last()]
+          (: descendant::*: don't include context node itself :)
+          satisfies descendant::*
+            [descendant::text() intersect $text]
+            [. intersect key('quotation.elements', local-name())]
+        )
+      ">
+        <xsl:value-of select="following::node()[not(ancestor-or-self::tei:note[not(current() intersect descendant::*)])][1]/self::text()[matches(., '^\s*[.,]')]/replace(., '^\s*([.,]+).*', '$1', 's')"/>
+      </xsl:when>
+      <!-- footnotes: place all following punctuation marks, except dash, before the footnote marker --> 
+      <!-- condition: the first preceding non-note sibling should not end in a "pulling punctuation 
+           quotes" context, unless the following text node starts with a question or quotation mark.
+      -->
+      <xsl:when test="
+        self::tei:note 
+        and (
+          not(
+            preceding-sibling::node()[not(self::tei:note)][1]
+            [local:endsWithPullingPunctuationQuotes(.)]
+          )
+          or 
+          following::node()[not(ancestor-or-self::tei:note
+            [not(current() intersect descendant::*)])][1]/self::text()
+            [matches(., '^\s*[\p{P}-[.,\p{Ps}\p{Pe}—]]')]
+        )
+      ">
+        <xsl:value-of select="following::node()[not(ancestor-or-self::tei:note[not(current() intersect descendant::*)])][1]/self::text()[matches(., '^\s*[\p{P}-[\p{Ps}\p{Pe}—]]')]/replace(., '^\s*([\p{P}-[\p{Ps}\p{Pe}—]]+).*', '$1', 's')"/>
+      </xsl:when>
+    </xsl:choose>
   </xsl:template>
   
   <!-- This template creates correct enumerations. -->
@@ -300,6 +337,45 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+  
+  <!-- text() starting with punctuation, and following either an element for which smart quotes 
+       or a footnote marker are being generated: skip starting punctuation (this is pulled into 
+       the quotation marks or before the footnote) -->
+  <xsl:template match="text()[matches(., '^\s*[\p{P}-[\p{Ps}\p{Pe}—]]')]" mode="#all">
+    <xsl:choose>
+      <!-- text following a valid "quotation element": skip starting comma or period -->
+      <xsl:when test="
+        self::text()[matches(., '^\s*[.,]')]
+        [preceding-sibling::node()[not(self::tei:note)][1]
+          [local:endsWithPullingPunctuationQuotes(.)]
+        ]
+      ">
+        <xsl:value-of select="replace(., '^(\s*)[.,]+', '$1', 's')"/>
+      </xsl:when>
+      <!-- text following a valid footnote marker: skip all punctuation except dash -->
+      <xsl:when test="self::text()[preceding::node()[1][ancestor::tei:note[not(current() intersect descendant::node())]]]">
+        <xsl:value-of select="replace(., '^(\s*)[\p{P}-[\p{Ps}\p{Pe}—]]+', '$1', 's')"/>
+      </xsl:when>
+      <!-- other text: just copy -->
+      <xsl:otherwise>
+        <xsl:value-of select="."/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- This function checks if a node ends with quotation marks that pull in subsequent punctuation. -->
+  <!-- For the context node and all its descendants containing the last non-empty text node, it is
+       tested if any of these is a "quotation element". -->
+  <xsl:function name="local:endsWithPullingPunctuationQuotes" as="xs:boolean">
+    <xsl:param name="node"/>
+    <xsl:value-of select="
+      some $text in $node/descendant::text()[normalize-space()][last()]
+      (: descendant-or-self::*: include preceding sibling node itself, too :)
+      satisfies $node/descendant-or-self::*
+        [descendant::text() intersect $text]
+        [. intersect key('quotation.elements', local-name())]
+    "/>
+  </xsl:function>
   
   <!-- This function creates a space-stripped copy of an author(ing instance) in
     a bibliography that can be compared to other author(ing instance)s, when

--- a/profiles/jtei/openedition/to.xsl
+++ b/profiles/jtei/openedition/to.xsl
@@ -350,10 +350,8 @@
   <xsl:template match="tei:note">
     <xsl:param name="note.counter" tunnel="yes" as="xs:integer" select="0"/>
     <xsl:param name="note.context" select="ancestor::*[self::tei:front|self::tei:body|self::tei:back]" tunnel="yes" as="element()?"/>
-    <!-- only 'pull' subsequent puntuation once (i.e. unless it is done for the preceding element) -->
-    <xsl:if test="not(preceding-sibling::node()[normalize-space()][1][. intersect key('quotation.elements', local-name())])">
-      <xsl:call-template name="include.punctuation"/>
-    </xsl:if>
+    <!-- 'pull' subsequent puntuation (if necessary) -->
+    <xsl:call-template name="include.punctuation"/>
     <xsl:copy>
       <xsl:apply-templates select="@*"/>
       <xsl:if test="not(@place)">
@@ -974,6 +972,12 @@
   <!-- default processing -->
   <!-- ================== -->  
   
+  <!-- Further processing of text is done in jtei.common.xsl, in order to guarantee uniform 
+       processing of punctuation following quotation marks or footnote markers. -->  
+  <xsl:template match="text()">
+    <xsl:apply-imports/>
+  </xsl:template>
+  
   <xsl:template match="@*|node()" priority="-1">
     <xsl:copy>
       <xsl:call-template name="get.rendition"/>
@@ -985,16 +989,6 @@
   <xsl:template match="comment()|processing-instruction()"/>
   
   <xsl:template match="tei:code/@lang|tei:row/@role|tei:row/@rows|tei:row/@cols|tei:cell/@role|tei:graphic/@width|tei:graphic/@height"/>
-  
-  <!-- text() following an element for which smart quotes are being generated: skip starting punctuation (this is pulled into the quotation marks) -->
-  <xsl:template match="text()[matches(., '^\s*[\p{P}-[:;\p{Ps}\p{Pe}—]]')]
-    [preceding-sibling::node()[not(self::tei:note)][1]
-    [. intersect key('quotation.elements', local-name())]]
-    |
-    text()[matches(., '^\s*[\p{P}-[\p{Ps}\p{Pe}]]')]
-    [preceding-sibling::node()[1][self::tei:note]]">
-    <xsl:value-of select="replace(., '^(\s*)[\p{P}-[\p{Ps}\p{Pe}]]+', '$1', 's')"/>
-  </xsl:template>
 
   <!-- ========= -->
   <!-- functions -->

--- a/profiles/jtei/pdf/to.xsl
+++ b/profiles/jtei/pdf/to.xsl
@@ -377,8 +377,7 @@
     <xsl:param name="note.context" select="ancestor::*[self::tei:front|self::tei:body|self::tei:back]" tunnel="yes" as="element()?"/>
     <xsl:variable name="note.nr" select="local:get.note.nr(.)"/>
     <!-- only 'pull' subsequent punctuation once (i.e. unless it is done for the preceding element) -->
-    <xsl:if test="not(preceding-sibling::node()[normalize-space()][1][. intersect key('quotation.elements', local-name())])">
-      <xsl:call-template name="include.punctuation"/>
+    <xsl:call-template name="include.punctuation"/>
     </xsl:if>
     <fo:inline font-size="5.4pt" vertical-align="super">
       <fo:basic-link internal-destination="{$note.context/name()}.note{$note.nr}" id="{$note.context/name()}.noteptr{$note.nr}">
@@ -1123,15 +1122,6 @@
       <fo:block/>
     </xsl:if>
   </xsl:template>
-  
-  <!-- text() following an element for which smart quotes are being generated: skip starting punctuation (this is pulled into the quotation marks) -->
-  <xsl:template match="text()[matches(., '^\s*[\p{P}-[:;\p{Ps}\p{Pe}—]]')]
-    [preceding-sibling::node()[not(self::tei:note)][1]
-    [. intersect key('quotation.elements', local-name())]]
-    |
-    text()[matches(., '^\s*[\p{P}-[\p{Ps}\p{Pe}]]')]
-    [preceding-sibling::node()[1][self::tei:note]]">
-    <xsl:value-of select="replace(., '^(\s*)[\p{P}-[\p{Ps}\p{Pe}]]+', '$1', 's')"/>
-  </xsl:template>
+
       
 </xsl:stylesheet>


### PR DESCRIPTION
…equent punctuation, which should now be fully compliant with CMOS:

  -only commas and periods should appear before closing quotation mark
  -(only the) innermost "quotation element" should "pull in" subsequent comma or period
   -all punctuation marks except dash should precede footnote markers