### PR TITLE
refined SVN keyword processing, so that unexpanded keywords (e.g. $Id…

### DIFF
--- a/profiles/jtei/jtei.common.xsl
+++ b/profiles/jtei/jtei.common.xsl
@@ -542,12 +542,20 @@
   </xsl:function>
   
   <!-- This function retrieves the value for an SVN keyword in a comment line -->
+  <!-- note: keyword can be 
+    -empty ($Id$)
+    -expanded ($Revision: 1234 $)
+  -->
   <xsl:function name="local:get.SVNkeyword">
     <xsl:param name="keyword.name"/>
-    <xsl:variable name="keyword.lines" select="$doc.root//comment()[contains(., concat('$', $keyword.name, ':'))][1]"/>
-    <xsl:copy-of select="for $keyword in tokenize(normalize-space($keyword.lines), '\$(\s+|$)')[starts-with(., concat('$', $keyword.name, ':'))][1]
-      return replace(normalize-space($keyword), '^.*?:\s+', '')
-      "/>
+    <xsl:variable name="keyword.lines" select="$doc.root//comment()[matches(., concat('\$', $keyword.name, '(\$|:)'))][1]"/>
+    <xsl:if test="$keyword.lines">
+      <xsl:analyze-string select="$keyword.lines" regex="\${$keyword.name}(\$|:[^$]+?\$(\s+|$))">
+        <xsl:matching-substring>
+          <xsl:value-of select="normalize-space(.)"/>
+        </xsl:matching-substring>
+      </xsl:analyze-string>
+    </xsl:if>
   </xsl:function>
   
 </xsl:stylesheet>

--- a/profiles/jtei/openedition/to.xsl
+++ b/profiles/jtei/openedition/to.xsl
@@ -324,9 +324,7 @@
       <div>
         <p rend="noindent" rendition="#metadata">
           <xsl:text>SVN keywords: </xsl:text>
-          <xsl:for-each select="local:get.SVNkeyword('Id')[.]">
-            <xsl:value-of select="concat('$Id: ', ., ' $')"/>
-          </xsl:for-each>
+          <xsl:value-of select="$metadata"/>
         </p>
       </div>
     </xsl:if>

--- a/profiles/jtei/pdf/to.xsl
+++ b/profiles/jtei/pdf/to.xsl
@@ -226,7 +226,6 @@
           </fo:list-item-body>
         </fo:list-item>
       </fo:list-block>
-      <xsl:call-template name="body-metadata"/>
     </fo:block>
   </xsl:template>
   
@@ -275,6 +274,7 @@
   
   <xsl:template name="front">
     <xsl:call-template name="article.title"/>
+    <xsl:call-template name="body-metadata"/>
     <xsl:apply-templates select="/tei:TEI/tei:text/tei:front/tei:div[@type='abstract']"/>
     <xsl:apply-templates select="/tei:TEI/tei:teiHeader/tei:profileDesc/tei:textClass"/>
     <xsl:call-template name="front.divs"/>

--- a/profiles/jtei/pdf/to.xsl
+++ b/profiles/jtei/pdf/to.xsl
@@ -155,35 +155,21 @@
       </fo:page-sequence-master>
     </fo:layout-master-set>
   </xsl:template>
-  
-  <!-- If (SVN) metadata are found, include them in custom PDF metadata. -->
-  <xsl:template name="PDF-metadata">
-    <xsl:variable name="metadata" select="local:parse.SVN.id()"/>
-    <xsl:if test="$metadata">
-      <fo:declarations>
-        <pdf:info xmlns:pdf="http://xmlgraphics.apache.org/fop/extensions/pdf">
-          <xsl:copy-of select="$metadata"/>
-        </pdf:info>
-      </fo:declarations>
-    </xsl:if>
-  </xsl:template>
-  
+    
   <!-- If (SVN) metadata are found, include them in a hidden paragraph in the body text. -->
   <xsl:template name="body-metadata">
-    <xsl:variable name="metadata" select="local:parse.SVN.id()"/>
+    <xsl:variable name="metadata" select="local:get.SVNkeyword('Id')"/>
     <xsl:if test="$metadata">
       <fo:block margin-top="1em" color="white" line-height="0px">
         <xsl:text>SVN keywords: </xsl:text>
-        <xsl:for-each select="local:get.SVNkeyword('Id')">
-          <xsl:value-of select="concat('$Id: ', ., ' $')"/>
-        </xsl:for-each>
+        <xsl:value-of select="$metadata"/>
       </fo:block>
     </xsl:if>
   </xsl:template>  
   
   <!-- This function parses the SVN ID keyword into custom PDF metadata fields. -->
   <xsl:function name="local:parse.SVN.id">
-    <xsl:for-each select="local:get.SVNkeyword('Id')">
+    <xsl:for-each select="replace(local:get.SVNkeyword('Id'), '^\$Id:\s*(.*?)\s\$$', '$1')[count(tokenize(., '\s')) = 5]">
       <pdf:name key="SVN revision" xmlns:pdf="http://xmlgraphics.apache.org/fop/extensions/pdf">
         <xsl:value-of select="tokenize(., '\s+')[2]"/>
       </pdf:name>
@@ -204,8 +190,6 @@
     <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format">
       <!-- page definitions  -->
       <xsl:call-template name="pageDef"/>
-      <!-- metadata -->
-      <xsl:call-template name="PDF-metadata"/>
       <!-- PDF outline -->
       <xsl:call-template name="PDF-outline"/>
       <fo:page-sequence


### PR DESCRIPTION
…$) are copied as well (in order to copy the unexpanded keywords to the debug output)

Also, removed the SVN metadata from the PDF properties, since these properties are proprietary (Adobe-only), and they disturbed the debug output.