### PR TITLE
change to full URLs for CSS imports

### DIFF
--- a/epub3/tei-to-epub3.xsl
+++ b/epub3/tei-to-epub3.xsl
@@ -68,9 +68,9 @@ of this software, even if advised of the possibility of such damage.
   <xsl:param name="bottomNavigationPanel">false</xsl:param>
   <xsl:param name="coverimage"/>
   <xsl:param name="createanttask">false</xsl:param>
-  <xsl:param name="cssFile">http://www.tei-c.org/release/xml/tei/stylesheet/tei.css</xsl:param>
-  <xsl:param name="cssODDFile">http://www.tei-c.org/release/xml/tei/stylesheet/odd.css</xsl:param>
-  <xsl:param name="cssPrintFile">http://www.tei-c.org/release/xml/tei/stylesheet/epub-print.css</xsl:param>
+  <xsl:param name="cssFile">https://www.tei-c.org/release/xml/tei/stylesheet/tei.css</xsl:param>
+  <xsl:param name="cssODDFile">https://www.tei-c.org/release/xml/tei/stylesheet/odd.css</xsl:param>
+  <xsl:param name="cssPrintFile">https://www.tei-c.org/release/xml/tei/stylesheet/epub-print.css</xsl:param>
   <xsl:param name="debug">false</xsl:param>
   <xsl:param name="directory">.</xsl:param>
   <xsl:param name="doctypePublic"/>

--- a/epub3/tei-to-epub3.xsl
+++ b/epub3/tei-to-epub3.xsl
@@ -68,9 +68,9 @@ of this software, even if advised of the possibility of such damage.
   <xsl:param name="bottomNavigationPanel">false</xsl:param>
   <xsl:param name="coverimage"/>
   <xsl:param name="createanttask">false</xsl:param>
-  <xsl:param name="cssFile">../css/tei.css</xsl:param>
-  <xsl:param name="cssODDFile">../css/odd.css</xsl:param>
-  <xsl:param name="cssPrintFile">../css/epub-print.css</xsl:param>
+  <xsl:param name="cssFile">http://www.tei-c.org/release/xml/tei/stylesheet/tei.css</xsl:param>
+  <xsl:param name="cssODDFile">http://www.tei-c.org/release/xml/tei/stylesheet/odd.css</xsl:param>
+  <xsl:param name="cssPrintFile">http://www.tei-c.org/release/xml/tei/stylesheet/epub-print.css</xsl:param>
   <xsl:param name="debug">false</xsl:param>
   <xsl:param name="directory">.</xsl:param>
   <xsl:param name="doctypePublic"/>


### PR DESCRIPTION
This PR fixes the issue #312 with incorrect relative paths to CSSs in the EPub transformation by simply providing full URLs.
Since those files get included via `unparsed-text()` it is not possible to a) use xml catalogs (see https://www.saxonica.com/html/documentation/sourcedocs/xml-catalogs.html) and b) to follow redirects.