### PR TITLE
wrap arabic text in hbox{} in verbatim environments 

### DIFF
--- a/latex/latex.xsl
+++ b/latex/latex.xsl
@@ -110,6 +110,11 @@ of this software, even if advised of the possibility of such damage.
 		   <xsl:value-of select="tei:escapeCharsVerbatim($words)"/>
 	           <xsl:text>}</xsl:text>
          </xsl:when>
+        <xsl:when test="lang('ar')">
+          <xsl:text>\hbox{</xsl:text>
+          <xsl:value-of select="tei:escapeCharsVerbatim($words)"/>
+          <xsl:text>}</xsl:text>
+        </xsl:when>
          <xsl:otherwise>
 	   <xsl:value-of select="tei:escapeCharsVerbatim($words)"/>
          </xsl:otherwise>


### PR DESCRIPTION
It's been easier than I thought because for LaTeX verbatim environments there's already some language support. Fixed it by adding another switch case for arabic (`@lang="ar"`), injecting an `\hbox{}`.

Result:

![Bildschirmfoto 2020-06-10 um 09 25 15](https://user-images.githubusercontent.com/2247936/84239456-cdd52580-aafc-11ea-86ee-4a54bd221783.png)
