### PR TITLE
Make teitoepub3 self-recognize just like teitoepub

### DIFF
--- a/bin/transformtei
+++ b/bin/transformtei
@@ -48,17 +48,19 @@ case $format in
 	;;
 esac
 
-if [ $script = "teitoepub" ]
-then
+case "$script" in
+    teitoepub*) # could be teitoepub or teitoepub3
 echo "  --fileperpage        # create output files one per page "
 echo "  --nocompress	     # disable compression of epub output file"
-fi
+    ;;
+esac
+
 echo 
 echo "  Options, shown with defaults:"
 echo "  --saxonjar=$SAXONJAR  # location of Saxon jar file"
 echo "  --trangjar=$TRANGJAR  # location of trang jar file"
-if [ $script = "teitoepub" ]
-then
+case "$script" in
+    teitoepub*) # could be teitoepub or teitoepub3
 echo "  --mediaoverlay       # create media overlays from timeline data "
 echo "  --coverimage=        # name of JPEG file for ebook cover"
 echo "  --css=               # supply name of CSS file "
@@ -68,7 +70,9 @@ echo "  --subject=           # subject/category for ebook "
 echo "  --uid=               # unique URN for ebook "
 echo "  --viewportwidth=     # viewport width for epub fixed-size pages "
 echo "  --viewportheight=    # viewport height for epub fixed-size pages "
-fi
+    ;;
+esac
+
 echo
 echo "Stylesheet family version: $version"
 }


### PR DESCRIPTION
teitoepub3 has not been offering all the same command-line options
as teitoepub because the checks for whether those options were
relevant were doing an equality comparison with "teitoepub" and
obviously "teitoepub3" fails that comparison. So make the checks
match either one (with or without the "3" at the end).