### PR TITLE
Issue 399 rng annotations

### DIFF
--- a/Test/expected-results/test.rng
+++ b/Test/expected-results/test.rng
@@ -3255,7 +3255,7 @@ Suggested values include: 1] volume (volume); 2] issue; 3] page (page); 4] line;
   </define>
   <define name="att.citeStructurePart.attribute.use">
     <attribute name="use">
-      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in <code xmlns="http://www.w3.org/1999/xhtml">@match</code>, which will either be a sibling attribute in the case of  or on the parent  in the case of .</a:documentation>
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in <code xmlns="http://www.w3.org/1999/xhtml">@match</code>, which will either be a sibling attribute in the case of `&lt;citeStructure&gt;` or on the parent `&lt;citeStructure&gt;` in the case of `&lt;citeData&gt;`.</a:documentation>
       <text/>
     </attribute>
   </define>
@@ -5944,7 +5944,7 @@ Sample values include: 1] first-line; 2] first-letter; 3] before; 4] after</a:do
         </rule>
       </pattern>
       <attribute name="match">
-        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with ) or relative. <code xmlns="http://www.w3.org/1999/xhtml">@match</code> on a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> without a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> parent must be an absolute XPath. If it is relative, its context is set by the <code xmlns="http://www.w3.org/1999/xhtml">@match</code> of the parent <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code>.</a:documentation>
+        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. <code xmlns="http://www.w3.org/1999/xhtml">@match</code> on a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> without a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> parent must be an absolute XPath. If it is relative, its context is set by the <code xmlns="http://www.w3.org/1999/xhtml">@match</code> of the parent <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code>.</a:documentation>
         <text/>
       </attribute>
       <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="test-citeStructure-match-citestructure-outer-match-constraint-rule-13">

--- a/Test/expected-results/test15.odd.rnc
+++ b/Test/expected-results/test15.odd.rnc
@@ -1660,7 +1660,7 @@ att.citeStructurePart.attribute.use =
     a:documentation [
       "(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in "
       ns1:code [ "@match" ]
-      ", which will either be a sibling attribute in the case of  or on the parent  in the case of ."
+      ", which will either be a sibling attribute in the case of `<citeStructure>` or on the parent `<citeStructure>` in the case of `<citeData>`."
     ]
   ]
   attribute use { text }
@@ -3863,7 +3863,7 @@ citeStructure =
        ],
     [
       a:documentation [
-        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with ) or relative. "
+        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. "
         ns1:code [ "@match" ]
         " on a "
         ns1:code [ "<citeStructure>" ]

--- a/Test/expected-results/test21.odd.rnc
+++ b/Test/expected-results/test21.odd.rnc
@@ -2053,7 +2053,7 @@ att.citeStructurePart.attribute.use =
     a:documentation [
       "(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in "
       ns1:code [ "@match" ]
-      ", which will either be a sibling attribute in the case of  or on the parent  in the case of ."
+      ", which will either be a sibling attribute in the case of `<citeStructure>` or on the parent `<citeStructure>` in the case of `<citeData>`."
     ]
   ]
   attribute use { text }
@@ -5565,7 +5565,7 @@ citeStructure =
        ],
     [
       a:documentation [
-        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with ) or relative. "
+        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. "
         ns1:code [ "@match" ]
         " on a "
         ns1:code [ "<citeStructure>" ]
@@ -6482,11 +6482,11 @@ alt =
       a:documentation [
         "Si l'attribut "
         ns1:code [ "@mode" ]
-        " a la valeur , chacune des valeurs de l'attribut "
+        " a la valeur `excl`, chacune des valeurs de l'attribut "
         ns1:code [ "@weights" ]
         " établit la probabilité que l'option correspondante soit vraie. Si l'attribut "
         ns1:code [ "@mode" ]
-        " a la valeur , chacune des valeurs de l'attribut "
+        " a la valeur `incl`, chacune des valeurs de l'attribut "
         ns1:code [ "@weights" ]
         " établit la probabilité que l'option correspondante soit vraie, étant posé qu'au moins une des autres options l'est aussi."
       ]

--- a/Test/expected-results/test30.rnc
+++ b/Test/expected-results/test30.rnc
@@ -2023,7 +2023,7 @@ Tatt.citeStructurePart.attribute.use =
     a:documentation [
       "(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in "
       ns1:code [ "@match" ]
-      ", which will either be a sibling attribute in the case of  or on the parent  in the case of ."
+      ", which will either be a sibling attribute in the case of `<citeStructure>` or on the parent `<citeStructure>` in the case of `<citeData>`."
     ]
   ]
   attribute use { text }
@@ -4272,7 +4272,7 @@ TciteStructure =
        ],
     [
       a:documentation [
-        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with ) or relative. "
+        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. "
         ns1:code [ "@match" ]
         " on a "
         ns1:code [ "<citeStructure>" ]

--- a/Test/expected-results/test33.rnc
+++ b/Test/expected-results/test33.rnc
@@ -1758,7 +1758,7 @@ tei_att.citeStructurePart.attribute.use =
     a:documentation [
       "(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in "
       ns1:code [ "@match" ]
-      ", which will either be a sibling attribute in the case of  or on the parent  in the case of ."
+      ", which will either be a sibling attribute in the case of `<citeStructure>` or on the parent `<citeStructure>` in the case of `<citeData>`."
     ]
   ]
   attribute use { text }
@@ -4043,7 +4043,7 @@ tei_citeStructure =
        ],
     [
       a:documentation [
-        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with ) or relative. "
+        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. "
         ns1:code [ "@match" ]
         " on a "
         ns1:code [ "<citeStructure>" ]

--- a/Test/expected-results/test34.rnc
+++ b/Test/expected-results/test34.rnc
@@ -1763,7 +1763,7 @@ tei_att.citeStructurePart.attribute.use =
     a:documentation [
       "(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in "
       ns1:code [ "@match" ]
-      ", which will either be a sibling attribute in the case of  or on the parent  in the case of ."
+      ", which will either be a sibling attribute in the case of `<citeStructure>` or on the parent `<citeStructure>` in the case of `<citeData>`."
     ]
   ]
   attribute use { text }
@@ -4048,7 +4048,7 @@ tei_citeStructure =
        ],
     [
       a:documentation [
-        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with ) or relative. "
+        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. "
         ns1:code [ "@match" ]
         " on a "
         ns1:code [ "<citeStructure>" ]

--- a/Test/expected-results/test35.rnc
+++ b/Test/expected-results/test35.rnc
@@ -1757,7 +1757,7 @@ tei_att.citeStructurePart.attribute.use =
     a:documentation [
       "(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in "
       ns1:code [ "@match" ]
-      ", which will either be a sibling attribute in the case of  or on the parent  in the case of ."
+      ", which will either be a sibling attribute in the case of `<citeStructure>` or on the parent `<citeStructure>` in the case of `<citeData>`."
     ]
   ]
   attribute use { text }
@@ -4022,7 +4022,7 @@ tei_citeStructure =
        ],
     [
       a:documentation [
-        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with ) or relative. "
+        "(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. "
         ns1:code [ "@match" ]
         " on a "
         ns1:code [ "<citeStructure>" ]

--- a/Test2/expected-results/testPure1.rng
+++ b/Test2/expected-results/testPure1.rng
@@ -3002,7 +3002,7 @@ Suggested values include: 1] volume (volume); 2] issue; 3] page (page); 4] line;
    </define>
    <define name="t_att.citeStructurePart.attribute.use">
       <attribute name="use">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in <code xmlns="http://www.w3.org/1999/xhtml">@match</code>, which will either be a sibling attribute in the case of  or on the parent  in the case of .</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(use) supplies an XPath selection pattern using the syntax defined in . The XPath pattern is relative to the context given in <code xmlns="http://www.w3.org/1999/xhtml">@match</code>, which will either be a sibling attribute in the case of `&lt;citeStructure&gt;` or on the parent `&lt;citeStructure&gt;` in the case of `&lt;citeData&gt;`.</a:documentation>
          <text/>
       </attribute>
    </define>
@@ -5618,7 +5618,7 @@ Sample values include: 1] first-line; 2] first-letter; 3] before; 4] after</a:do
             </rule>
          </pattern>
          <attribute name="match">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with ) or relative. <code xmlns="http://www.w3.org/1999/xhtml">@match</code> on a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> without a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> parent must be an absolute XPath. If it is relative, its context is set by the <code xmlns="http://www.w3.org/1999/xhtml">@match</code> of the parent <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code>.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(match) supplies an XPath selection pattern using the syntax defined in  which identifies a set of nodes which are citable structural components. The expression may be absolute (beginning with `/`) or relative. <code xmlns="http://www.w3.org/1999/xhtml">@match</code> on a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> without a <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code> parent must be an absolute XPath. If it is relative, its context is set by the <code xmlns="http://www.w3.org/1999/xhtml">@match</code> of the parent <code xmlns="http://www.w3.org/1999/xhtml">&lt;citeStructure&gt;</code>.</a:documentation>
             <text/>
          </attribute>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"

--- a/odds/odd2relax.xsl
+++ b/odds/odd2relax.xsl
@@ -468,6 +468,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template name="refdoc"/>
   <xsl:template name="typewriter">
       <xsl:param name="text"/>
+      <xsl:sequence select="'`' || $text || '`'"/>
   </xsl:template>
 
   <xsl:template match="processing-instruction()" mode="tangle">


### PR DESCRIPTION
This is a simple fix for the exact issue reported. Instead of dropping the contents of the code element completely, as was happening before, it outputs them as text surrounded by backticks, which is (we think) a reasonable way to signal that something is inline code in a plain-text context.