### PR TITLE
Fix #516: duplication of ids in HTML transformation

### DIFF
--- a/Test/expected-results/test32.html
+++ b/Test/expected-results/test32.html
@@ -4636,19 +4636,19 @@ color:orange;
         <span class="head">Bibliografija</span>
       </h2>
       <ol class="listBibl">
-        <li id="Kovacic">
+        <li>
           <div class="biblfree" id="Kovacic">KOVAČIČ – Fran Kovačič: Služabnik božji Anton Martin Slomšek, knezoškof lavantinski. Družba sv. Mohorja, Celje, I. 1934, II. 1935. </div>
         </li>
-        <li id="Kramberger">
+        <li>
           <div class="biblfree" id="Kramberger">KRAMBERGER – Franc Kramberger: Anton Martin Slomšek. Inventarji 5, Pokrajinski arhiv Maribor, Maribor 1993.</div>
         </li>
-        <li id="Kumer">
+        <li>
           <div class="biblfree" id="Kumer">KUMER – Zmaga Kumer: Ljudska glasbila in godci na Slovenskem. Slovenska matica, Ljubljana, 1983.</div>
         </li>
-        <li id="Pletersnik">
+        <li>
           <div class="biblfree" id="Pletersnik">PLETERŠNIK – Maks Pleteršnik: Slovensko-nemški slovar. Založilo knezoškofijstvo, Ljubljana 1894, 1895.</div>
         </li>
-        <li id="Smolik">
+        <li>
           <div class="biblfree" id="Smolik">SMOLIK – Leto svetnikov II, ur. Marjan Smolik, Mohorjeva družba, Celje, 2000. </div>
         </li>
       </ol>

--- a/html/html_core.xsl
+++ b/html/html_core.xsl
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet                 xmlns:m="http://www.w3.org/1998/Math/MathML"
-				xmlns="http://www.w3.org/1999/xhtml"
-				xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xs="http://www.w3.org/2001/XMLSchema"
-				xmlns:html="http://www.w3.org/1999/xhtml"
-				xmlns:fn="http://www.w3.org/2005/xpath-functions"
-				xmlns:rng="http://relaxng.org/ns/structure/1.0"
-				xmlns:tei="http://www.tei-c.org/ns/1.0"
-				xmlns:teix="http://www.tei-c.org/ns/Examples"
-				xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-				xmlns:teidocx="http://www.tei-c.org/ns/teidocx/1.0"
-				exclude-result-prefixes="#all" version="2.0">
+                                xmlns="http://www.w3.org/1999/xhtml"
+                                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                                xmlns:fo="http://www.w3.org/1999/XSL/Format"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                xmlns:html="http://www.w3.org/1999/xhtml"
+                                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                                xmlns:tei="http://www.tei-c.org/ns/1.0"
+                                xmlns:teix="http://www.tei-c.org/ns/Examples"
+                                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                                xmlns:teidocx="http://www.tei-c.org/ns/teidocx/1.0"
+                                exclude-result-prefixes="#all" version="2.0">
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" scope="stylesheet" type="stylesheet">
     <desc>
       <p> TEI stylesheet dealing with elements from the core module, making
@@ -22,7 +22,7 @@
 Unported License http://creativecommons.org/licenses/by-sa/3.0/ 
 
 2. http://www.opensource.org/licenses/BSD-2-Clause
-		
+                
 
 
 Redistribution and use in source and binary forms, with or without
@@ -66,23 +66,23 @@ of this software, even if advised of the possibility of such damage.
       </xsl:when>
       <xsl:when test="parent::tei:sp">
         <div>
-	  <xsl:if test="@xml:id">
-	    <xsl:call-template name="makeAnchor"/>
-	  </xsl:if>
+          <xsl:if test="@xml:id">
+            <xsl:call-template name="makeAnchor"/>
+          </xsl:if>
           <xsl:call-template name="makeRendition">
-	    <xsl:with-param name="default">spProse</xsl:with-param>
-	  </xsl:call-template>
+            <xsl:with-param name="default">spProse</xsl:with-param>
+          </xsl:call-template>
           <xsl:apply-templates/>
         </div>
       </xsl:when>
       <xsl:otherwise>
         <div>
-	  <xsl:if test="@xml:id">
-	    <xsl:call-template name="makeAnchor"/>
-	  </xsl:if>
+          <xsl:if test="@xml:id">
+            <xsl:call-template name="makeAnchor"/>
+          </xsl:if>
           <xsl:call-template name="makeRendition">
-	    <xsl:with-param name="default">false</xsl:with-param>
-	  </xsl:call-template>
+            <xsl:with-param name="default">false</xsl:with-param>
+          </xsl:call-template>
           <xsl:apply-templates/>
         </div>
       </xsl:otherwise>
@@ -147,16 +147,16 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:cit">
     <xsl:choose>
       <xsl:when test="(tei:match(@rend,'display') and tei:quote) or
-		      tei:quote/tei:l or tei:quote/tei:p">
+                      tei:quote/tei:l or tei:quote/tei:p">
         <div>
           <xsl:call-template name="makeRendition">
-	    <xsl:with-param name="auto">cit</xsl:with-param>
-	  </xsl:call-template>
-	  <xsl:if test="@xml:id">
-	    <xsl:attribute name="id">
-	      <xsl:value-of select="@xml:id"/>
-	    </xsl:attribute>
-	  </xsl:if>
+            <xsl:with-param name="auto">cit</xsl:with-param>
+          </xsl:call-template>
+          <xsl:if test="@xml:id">
+            <xsl:attribute name="id">
+              <xsl:value-of select="@xml:id"/>
+            </xsl:attribute>
+          </xsl:if>
           <xsl:if test="@n">
             <xsl:text>(</xsl:text>
             <xsl:value-of select="@n"/>
@@ -220,7 +220,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:code">
     <code>
       <xsl:call-template name="makeRendition">
-	<xsl:with-param name="default">false</xsl:with-param>
+        <xsl:with-param name="default">false</xsl:with-param>
       </xsl:call-template>
       <xsl:apply-templates/>
     </code>
@@ -253,7 +253,7 @@ of this software, even if advised of the possibility of such damage.
       </xsl:if>
       <xsl:apply-templates/>
       <a href="#{$myID}" class="anchorlink">
-	<xsl:text>&#x2693;</xsl:text>
+        <xsl:text>&#x2693;</xsl:text>
       </a>
     </pre>
   </xsl:template>
@@ -263,7 +263,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:emph">
     <em>
       <xsl:call-template name="makeRendition">
-	<xsl:with-param name="default">false</xsl:with-param>
+        <xsl:with-param name="default">false</xsl:with-param>
       </xsl:call-template>
       <xsl:apply-templates/>
     </em>
@@ -319,7 +319,7 @@ of this software, even if advised of the possibility of such damage.
           <xsl:value-of select="substring-after(@rend,'content:')"/>
         </xsl:when>
         <xsl:otherwise>
-	  <xsl:call-template name="makeRendition"/>
+          <xsl:call-template name="makeRendition"/>
           <xsl:text> [...]</xsl:text>
         </xsl:otherwise>
       </xsl:choose>
@@ -361,19 +361,19 @@ of this software, even if advised of the possibility of such damage.
     </xsl:variable>
     <xsl:choose>
       <xsl:when test="parent::tei:group or parent::tei:body or parent::tei:front or parent::tei:back">
-	<xsl:call-template name="splitHTMLBlocks">
-	  <xsl:with-param name="element">h1</xsl:with-param>
-	  <xsl:with-param name="content">
-	    <xsl:apply-templates/>
-	  </xsl:with-param>
-	  <xsl:with-param name="copyid">false</xsl:with-param>
-	</xsl:call-template>
+        <xsl:call-template name="splitHTMLBlocks">
+          <xsl:with-param name="element">h1</xsl:with-param>
+          <xsl:with-param name="content">
+            <xsl:apply-templates/>
+          </xsl:with-param>
+          <xsl:with-param name="copyid">false</xsl:with-param>
+        </xsl:call-template>
       </xsl:when>
       <xsl:when test="parent::tei:argument">
         <div>
           <xsl:call-template name="makeRendition">
-	    <xsl:with-param name="default">false</xsl:with-param>
-	  </xsl:call-template>
+            <xsl:with-param name="default">false</xsl:with-param>
+          </xsl:call-template>
           <xsl:apply-templates/>
         </div>
       </xsl:when>
@@ -381,33 +381,33 @@ of this software, even if advised of the possibility of such damage.
         <xsl:apply-templates/>
       </xsl:when>
       <xsl:when test="not(preceding-sibling::tei:head) and starts-with($parentName,'div') and (tei:keepDivOnPage(..) or 
-		      number($depth)  &gt; number($splitLevel))">
-	  <xsl:variable name="Heading">
-	    <xsl:for-each select="..">
-	      <xsl:call-template name="splitHTMLBlocks">
-		<xsl:with-param name="element" select="if (number($depth)+$divOffset &gt;6) then 'div'
-					       else
-					       concat('h',number($depth)+$divOffset)"/>
-		<xsl:with-param name="content">
-		  <xsl:call-template name="sectionHeadHook"/>
-		  <xsl:call-template name="header">
-		    <xsl:with-param name="display">full</xsl:with-param>
-		  </xsl:call-template>
-		</xsl:with-param>
-		<xsl:with-param name="copyid">false</xsl:with-param>
-	      </xsl:call-template>
-	    </xsl:for-each>
-	  </xsl:variable>
-	  <xsl:choose>
-	    <xsl:when test="$outputTarget='html5' and number($depth)  &lt; 1">
-	      <header>
-		<xsl:copy-of select="$Heading"/>
-	      </header>
-	    </xsl:when>
-	    <xsl:otherwise>
-	      <xsl:copy-of select="$Heading"/>
-	    </xsl:otherwise>
-	  </xsl:choose>
+                      number($depth)  &gt; number($splitLevel))">
+          <xsl:variable name="Heading">
+            <xsl:for-each select="..">
+              <xsl:call-template name="splitHTMLBlocks">
+                <xsl:with-param name="element" select="if (number($depth)+$divOffset &gt;6) then 'div'
+                                               else
+                                               concat('h',number($depth)+$divOffset)"/>
+                <xsl:with-param name="content">
+                  <xsl:call-template name="sectionHeadHook"/>
+                  <xsl:call-template name="header">
+                    <xsl:with-param name="display">full</xsl:with-param>
+                  </xsl:call-template>
+                </xsl:with-param>
+                <xsl:with-param name="copyid">false</xsl:with-param>
+              </xsl:call-template>
+            </xsl:for-each>
+          </xsl:variable>
+          <xsl:choose>
+            <xsl:when test="$outputTarget='html5' and number($depth)  &lt; 1">
+              <header>
+                <xsl:copy-of select="$Heading"/>
+              </header>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:copy-of select="$Heading"/>
+            </xsl:otherwise>
+          </xsl:choose>
       </xsl:when>
     </xsl:choose>
   </xsl:template>
@@ -422,7 +422,7 @@ of this software, even if advised of the possibility of such damage.
       <xsl:with-param name="element">span</xsl:with-param>
       <xsl:with-param name="class">head</xsl:with-param>
       <xsl:with-param name="content">
-	<xsl:apply-templates/>
+        <xsl:apply-templates/>
       </xsl:with-param>
     </xsl:call-template>
   </xsl:template>
@@ -432,31 +432,31 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:hi">
     <xsl:variable name="rend">
       <x>
-	<xsl:call-template name="makeRendition"/>
+        <xsl:call-template name="makeRendition"/>
       </x>
     </xsl:variable>
     <xsl:variable name="container" select="if (tei:render-superscript(.)) then 'sup' 
-					   else if (tei:render-subscript(.)) then 'sub' 
-					   else if (tei:match(@rend,'code')) then 'code' else 'span'"/>
+                                           else if (tei:render-subscript(.)) then 'sub' 
+                                           else if (tei:match(@rend,'code')) then 'code' else 'span'"/>
     <xsl:for-each-group select="*|text()"
-			group-adjacent="if (self::tei:note or
-					self::tei:q/tei:l or
-					self::tei:q/tei:p or
-					self::tei:table or
-					self::tei:list or 
-					self::tei:figure)  then 1  
-					else 2">
+                        group-adjacent="if (self::tei:note or
+                                        self::tei:q/tei:l or
+                                        self::tei:q/tei:p or
+                                        self::tei:table or
+                                        self::tei:list or 
+                                        self::tei:figure)  then 1  
+                                        else 2">
       <xsl:choose>
-	<xsl:when test="current-grouping-key()=1">
-	  <xsl:apply-templates select="current-group()"/>
-	</xsl:when>
-	<xsl:otherwise>
-	  <xsl:element name="{$container}">
-	    <xsl:copy-of select="$rend/*/@*"/>
-	    <xsl:apply-templates select="current-group()"/>
-	  </xsl:element>
-<!--	  ***<xsl:value-of select="current-group()"/>*** -->
-	</xsl:otherwise>
+        <xsl:when test="current-grouping-key()=1">
+          <xsl:apply-templates select="current-group()"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:element name="{$container}">
+            <xsl:copy-of select="$rend/*/@*"/>
+            <xsl:apply-templates select="current-group()"/>
+          </xsl:element>
+<!--      ***<xsl:value-of select="current-group()"/>*** -->
+        </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each-group>
   </xsl:template>
@@ -466,7 +466,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:item" mode="bibl">
     <p>      
       <xsl:if test="@xml:id">
-	<xsl:call-template name="makeAnchor"/>
+        <xsl:call-template name="makeAnchor"/>
       </xsl:if>
       <xsl:apply-templates/>
     </p>
@@ -482,9 +482,9 @@ of this software, even if advised of the possibility of such damage.
         </strong>
       </td>
       <td>
-	<xsl:if test="@xml:id">
-	  <xsl:call-template name="makeAnchor"/>
-	</xsl:if>
+        <xsl:if test="@xml:id">
+          <xsl:call-template name="makeAnchor"/>
+        </xsl:if>
         <xsl:apply-templates/>
       </td>
     </tr>
@@ -496,7 +496,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:item" mode="gloss">
     <dt>
       <xsl:if test="@xml:id">
-	<xsl:call-template name="makeAnchor"/>
+        <xsl:call-template name="makeAnchor"/>
       </xsl:if>
       <xsl:apply-templates mode="print" select="preceding-sibling::tei:label[1]"/>
     </dt>
@@ -510,7 +510,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:item/tei:label|tei:eTree/tei:label|tei:eLeaf/tei:label">
     <span>
       <xsl:call-template name="makeRendition">
-	<xsl:with-param name="default" select="@type"/>
+        <xsl:with-param name="default" select="@type"/>
       </xsl:call-template>
       <xsl:apply-templates/>
     </span>
@@ -521,10 +521,10 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:label" mode="print">
     <span>
       <xsl:if test="@xml:id">
-	<xsl:call-template name="makeAnchor"/>
+        <xsl:call-template name="makeAnchor"/>
       </xsl:if>
       <xsl:call-template name="makeRendition">
-	<xsl:with-param name="default">false</xsl:with-param>
+        <xsl:with-param name="default">false</xsl:with-param>
       </xsl:call-template>
       <xsl:apply-templates/>
     </span>
@@ -535,14 +535,14 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template name="lineBreak">
     <br>
       <xsl:call-template name="makeRendition">
-	<xsl:with-param name="default">false</xsl:with-param>
+        <xsl:with-param name="default">false</xsl:with-param>
       </xsl:call-template>
     </br>
   </xsl:template>
   <xsl:template name="lineBreakAsPara">
     <br>
       <xsl:call-template name="makeRendition">
-	<xsl:with-param name="default">false</xsl:with-param>
+        <xsl:with-param name="default">false</xsl:with-param>
       </xsl:call-template>
     </br>
   </xsl:template>
@@ -552,7 +552,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:l">
     <xsl:element name="{if (ancestor::tei:hi) then 'span' else 'div'}">
       <xsl:if test="@xml:id">
-	<xsl:call-template name="makeAnchor"/>
+        <xsl:call-template name="makeAnchor"/>
       </xsl:if>
       <xsl:call-template name="makeRendition"/>
       <xsl:choose>
@@ -589,17 +589,17 @@ of this software, even if advised of the possibility of such damage.
               <div>
                 <xsl:for-each select="..">
                   <xsl:call-template name="makeRendition"/>
-		  <xsl:attribute name="id">
-		    <xsl:choose>
-		      <xsl:when test="@xml:id">
-			<xsl:value-of select="@xml:id"/>
-			<xsl:text>continued</xsl:text>
-		      </xsl:when>
-		      <xsl:otherwise>
-			<xsl:text>false</xsl:text>
-		      </xsl:otherwise>
-		    </xsl:choose>
-		  </xsl:attribute>
+                  <xsl:attribute name="id">
+                    <xsl:choose>
+                      <xsl:when test="@xml:id">
+                        <xsl:value-of select="@xml:id"/>
+                        <xsl:text>continued</xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:text>false</xsl:text>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  </xsl:attribute>
                 </xsl:for-each>
                 <xsl:apply-templates select="current-group() except ."/>
               </div>
@@ -617,9 +617,9 @@ of this software, even if advised of the possibility of such damage.
       </xsl:when>
       <xsl:otherwise>
         <div>
-	  <xsl:if test="@xml:id">
-	    <xsl:call-template name="makeAnchor"/>
-	  </xsl:if>
+          <xsl:if test="@xml:id">
+            <xsl:call-template name="makeAnchor"/>
+          </xsl:if>
           <xsl:call-template name="makeRendition"/>
           <xsl:apply-templates/>
         </div>
@@ -667,7 +667,7 @@ of this software, even if advised of the possibility of such damage.
           <table>
             <xsl:call-template name="makeRendition">
               <xsl:with-param name="default">false</xsl:with-param>
-	    </xsl:call-template>
+            </xsl:call-template>
             <tr>
               <td style="vertical-align:top;">
                 <dl>
@@ -689,7 +689,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:with-param name="default">false</xsl:with-param>
           </xsl:call-template>
           <xsl:apply-templates mode="gloss"
-			       select="*[not(self::tei:head or self::tei:trailer)]"/>
+                               select="*[not(self::tei:head or self::tei:trailer)]"/>
         </dl>
       </xsl:when>
       <xsl:when test="tei:isGlossTable(.)">
@@ -698,7 +698,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:with-param name="default">false</xsl:with-param>
           </xsl:call-template>
           <xsl:apply-templates mode="glosstable"
-			       select="*[not(self::tei:head  or self::tei:trailer)]"/>
+                               select="*[not(self::tei:head  or self::tei:trailer)]"/>
         </table>
       </xsl:when>
       <xsl:when test="tei:isInlineList(.)">
@@ -713,7 +713,7 @@ of this software, even if advised of the possibility of such damage.
         <xsl:apply-templates select="*[not(self::tei:head or self::tei:trailer)]"  mode="bibl"/>
       </xsl:when>
       <xsl:otherwise>
-	<xsl:element name="{if (tei:isOrderedList(.)) then 'ol' else 'ul'}">
+        <xsl:element name="{if (tei:isOrderedList(.)) then 'ol' else 'ul'}">
           <xsl:call-template name="makeRendition">
             <xsl:with-param name="default">false</xsl:with-param>
           </xsl:call-template>
@@ -723,13 +723,13 @@ of this software, even if advised of the possibility of such damage.
             </xsl:attribute>
           </xsl:if>
           <xsl:apply-templates select="*[not(self::tei:head or self::tei:trailer)]" />
-	</xsl:element>
+        </xsl:element>
           <xsl:apply-templates select="tei:trailer" />
       </xsl:otherwise>
     </xsl:choose>
     </xsl:variable>
     <!--
-	<xsl:variable name="n">
+        <xsl:variable name="n">
       <xsl:number level="any"/>
     </xsl:variable>
     <xsl:result-document href="/tmp/list{$n}.xml">
@@ -780,50 +780,50 @@ of this software, even if advised of the possibility of such damage.
     </xsl:if>
     <xsl:choose>
       <xsl:when test="tei:biblStruct and $biblioStyle='mla'">
-	<div type="listBibl" xmlns="http://www.w3.org/1999/xhtml">	  
-	<xsl:for-each select="tei:biblStruct">
-	  <p class="hang" xmlns="http://www.w3.org/1999/xhtml">
-	    <xsl:apply-templates select="tei:analytic" mode="mla"/>
-	    <xsl:apply-templates select="tei:monogr" mode="mla"/>
-	    <xsl:apply-templates select="tei:relatedItem" mode="mla"/>
-	    <xsl:choose>
-	      <xsl:when test="tei:note">
-		<xsl:apply-templates select="tei:note"/>
-	      </xsl:when>
-	      <xsl:when test="*//tei:ref/@target and not(contains(*//tei:ref/@target, '#'))">
-		<xsl:text>Web.&#10;</xsl:text>
-		<xsl:if test="*//tei:imprint/tei:date/@type='access'">
-		  <xsl:value-of select="*//tei:imprint/tei:date[@type='access']"/>
-		  <xsl:text>.</xsl:text>
-		</xsl:if>
-	      </xsl:when>
-	      <xsl:when test="tei:analytic/tei:title[@level='u'] or tei:monogr/tei:title[@level='u']"/>
-	      <xsl:otherwise>Print.&#10;</xsl:otherwise>
-	    </xsl:choose>
-	    <xsl:if test="tei:monogr/tei:imprint/tei:extent"><xsl:value-of select="tei:monogr/tei:imprint/tei:extent"/>. </xsl:if>
-	    <xsl:if test="tei:series/tei:title[@level='s']">
-	      <xsl:apply-templates select="tei:series/tei:title[@level='s']"/>
-	      <xsl:text>. </xsl:text>
-	    </xsl:if>
-	  </p>
-	</xsl:for-each>
-	</div>
+        <div type="listBibl" xmlns="http://www.w3.org/1999/xhtml">        
+        <xsl:for-each select="tei:biblStruct">
+          <p class="hang" xmlns="http://www.w3.org/1999/xhtml">
+            <xsl:apply-templates select="tei:analytic" mode="mla"/>
+            <xsl:apply-templates select="tei:monogr" mode="mla"/>
+            <xsl:apply-templates select="tei:relatedItem" mode="mla"/>
+            <xsl:choose>
+              <xsl:when test="tei:note">
+                <xsl:apply-templates select="tei:note"/>
+              </xsl:when>
+              <xsl:when test="*//tei:ref/@target and not(contains(*//tei:ref/@target, '#'))">
+                <xsl:text>Web.&#10;</xsl:text>
+                <xsl:if test="*//tei:imprint/tei:date/@type='access'">
+                  <xsl:value-of select="*//tei:imprint/tei:date[@type='access']"/>
+                  <xsl:text>.</xsl:text>
+                </xsl:if>
+              </xsl:when>
+              <xsl:when test="tei:analytic/tei:title[@level='u'] or tei:monogr/tei:title[@level='u']"/>
+              <xsl:otherwise>Print.&#10;</xsl:otherwise>
+            </xsl:choose>
+            <xsl:if test="tei:monogr/tei:imprint/tei:extent"><xsl:value-of select="tei:monogr/tei:imprint/tei:extent"/>. </xsl:if>
+            <xsl:if test="tei:series/tei:title[@level='s']">
+              <xsl:apply-templates select="tei:series/tei:title[@level='s']"/>
+              <xsl:text>. </xsl:text>
+            </xsl:if>
+          </p>
+        </xsl:for-each>
+        </div>
       </xsl:when>
       <xsl:when test="tei:biblStruct and not(tei:bibl)">
         <ol class="listBibl {$biblioStyle}">
           <xsl:for-each select="tei:biblStruct">
-	    <xsl:sort select="lower-case(normalize-space((@sortKey,tei:*[1]/tei:author/tei:surname
-			      ,tei:*[1]/tei:author/tei:orgName
-			      ,tei:*[1]/tei:author/tei:name
-			      ,tei:*[1]/tei:author
-			      ,tei:*[1]/tei:editor/tei:surname
-			      ,tei:*[1]/tei:editor/tei:name
-			      ,tei:*[1]/tei:editor
-			      ,tei:*[1]/tei:title[1])[1]))"/>
-	    <xsl:sort select="lower-case(normalize-space((
-			      tei:*[1]/tei:author/tei:forename
-			      ,tei:*[1]/tei:editor/tei:forename
-			      ,'')[1]))"/>
+            <xsl:sort select="lower-case(normalize-space((@sortKey,tei:*[1]/tei:author/tei:surname
+                              ,tei:*[1]/tei:author/tei:orgName
+                              ,tei:*[1]/tei:author/tei:name
+                              ,tei:*[1]/tei:author
+                              ,tei:*[1]/tei:editor/tei:surname
+                              ,tei:*[1]/tei:editor/tei:name
+                              ,tei:*[1]/tei:editor
+                              ,tei:*[1]/tei:title[1])[1]))"/>
+            <xsl:sort select="lower-case(normalize-space((
+                              tei:*[1]/tei:author/tei:forename
+                              ,tei:*[1]/tei:editor/tei:forename
+                              ,'')[1]))"/>
             <xsl:sort select="tei:monogr/tei:imprint/tei:date"/>
             <li>
               <xsl:call-template name="makeAnchor"/>
@@ -833,23 +833,24 @@ of this software, even if advised of the possibility of such damage.
         </ol>
       </xsl:when>
       <xsl:when test="tei:msDesc">
-	<xsl:for-each select="*[not(self::tei:head)]">
-	  <div class="msDesc">
-	    <xsl:apply-templates/>
-	  </div>
-	</xsl:for-each>
+        <xsl:for-each select="*[not(self::tei:head)]">
+          <div class="msDesc">
+            <xsl:apply-templates/>
+          </div>
+        </xsl:for-each>
       </xsl:when>
       <xsl:otherwise>
         <ol class="listBibl">
           <xsl:for-each select="*[not(self::tei:head)]">
             <li>
-             <xsl:if test="not(@xml:id)">
-               <xsl:call-template name="makeAnchor">
-                <xsl:with-param name="name">
-                  <xsl:apply-templates mode="ident" select="."/>
-                </xsl:with-param>
-              </xsl:call-template></xsl:if>
-              <xsl:apply-templates select="."/>
+              <xsl:if test="not(@xml:id)">
+                <xsl:call-template name="makeAnchor">
+                  <xsl:with-param name="name">
+                    <xsl:apply-templates mode="ident" select="."/>
+                  </xsl:with-param>
+                </xsl:call-template>
+             </xsl:if>
+             <xsl:apply-templates select="."/>
             </li>
           </xsl:for-each>
         </ol>
@@ -882,21 +883,21 @@ of this software, even if advised of the possibility of such damage.
     </xsl:variable>
     <span>
       <xsl:call-template name="makeRendition">
-	<xsl:with-param name="auto">note</xsl:with-param>
+        <xsl:with-param name="auto">note</xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="makeAnchor">
-	<xsl:with-param name="name" select="$identifier"/>
+        <xsl:with-param name="name" select="$identifier"/>
       </xsl:call-template>
       <span class="noteLabel">
-	<xsl:choose>
-	  <xsl:when test="@n">
-	    <xsl:value-of select="@n"/>
-	  </xsl:when>
-	  <xsl:otherwise>
-	    <xsl:sequence select="tei:i18n('Note')"/>
-	    <xsl:text>: </xsl:text>
-	  </xsl:otherwise>
-	</xsl:choose>
+        <xsl:choose>
+          <xsl:when test="@n">
+            <xsl:value-of select="@n"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:sequence select="tei:i18n('Note')"/>
+            <xsl:text>: </xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
       </span>
       <xsl:apply-templates/>
     </span>
@@ -915,42 +916,42 @@ of this software, even if advised of the possibility of such damage.
     </xsl:variable>
     <xsl:element name="{if (tei:isInline(.)) then 'span' else 'div' }">
       <xsl:call-template name="makeAnchor">
-	<xsl:with-param name="name" select="concat($identifier,'_return')"/>
+        <xsl:with-param name="name" select="concat($identifier,'_return')"/>
       </xsl:call-template>
       <xsl:variable name="note-title">
-	<xsl:variable name="note-text">
-	  <xsl:apply-templates mode="plain"/>
-	</xsl:variable>
-	<xsl:value-of select="substring($note-text,1,150)"/>
-	<xsl:if test="string-length($note-text) &gt; 150">
-	  <xsl:text>…</xsl:text>
-	</xsl:if>
+        <xsl:variable name="note-text">
+          <xsl:apply-templates mode="plain"/>
+        </xsl:variable>
+        <xsl:value-of select="substring($note-text,1,150)"/>
+        <xsl:if test="string-length($note-text) &gt; 150">
+          <xsl:text>…</xsl:text>
+        </xsl:if>
       </xsl:variable>
       <xsl:choose>
-	<xsl:when test="$footnoteFile='true'">
-	  <a class="notelink" title="{normalize-space($note-title)}" href="{$masterFile}-notes.html#{$identifier}">
-	    <xsl:element name="{if (tei:match(@rend,'nosup')) then 'span' else 'sup'}">
-	      <xsl:call-template name="noteN"/>
-	    </xsl:element>
-	  </a>
-	  <xsl:if test="following-sibling::node()[1][self::tei:note]">
-	    <xsl:element name="{if (tei:match(@rend,'nosup')) then 'span' else 'sup'}">
-	      <xsl:text>,</xsl:text>
-	    </xsl:element>
-	  </xsl:if>
-	</xsl:when>
-	<xsl:otherwise>
-	  <a class="notelink" title="{normalize-space($note-title)}" href="#{$identifier}">
-	    <xsl:element name="{if (tei:match(@rend,'nosup')) then 'span' else 'sup'}">				  
-	      <xsl:call-template name="noteN"/>
-	    </xsl:element>
-	  </a>
-	  <xsl:if test="following-sibling::node()[1][self::tei:note]">
-	    <xsl:element name="{if (tei:match(@rend,'nosup')) then 'span' else 'sup'}">
-	      <xsl:text>,</xsl:text>
-	    </xsl:element>
-	  </xsl:if>
-	</xsl:otherwise>
+        <xsl:when test="$footnoteFile='true'">
+          <a class="notelink" title="{normalize-space($note-title)}" href="{$masterFile}-notes.html#{$identifier}">
+            <xsl:element name="{if (tei:match(@rend,'nosup')) then 'span' else 'sup'}">
+              <xsl:call-template name="noteN"/>
+            </xsl:element>
+          </a>
+          <xsl:if test="following-sibling::node()[1][self::tei:note]">
+            <xsl:element name="{if (tei:match(@rend,'nosup')) then 'span' else 'sup'}">
+              <xsl:text>,</xsl:text>
+            </xsl:element>
+          </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
+          <a class="notelink" title="{normalize-space($note-title)}" href="#{$identifier}">
+            <xsl:element name="{if (tei:match(@rend,'nosup')) then 'span' else 'sup'}">                           
+              <xsl:call-template name="noteN"/>
+            </xsl:element>
+          </a>
+          <xsl:if test="following-sibling::node()[1][self::tei:note]">
+            <xsl:element name="{if (tei:match(@rend,'nosup')) then 'span' else 'sup'}">
+              <xsl:text>,</xsl:text>
+            </xsl:element>
+          </xsl:if>
+        </xsl:otherwise>
       </xsl:choose>
     </xsl:element>
   </xsl:template>
@@ -965,21 +966,21 @@ of this software, even if advised of the possibility of such damage.
     <xsl:element name="{if (tei:isInline(.)) then 'span' else 'div'}">
       <xsl:attribute name="class">note</xsl:attribute>
       <xsl:call-template name="makeRendition">
-	<xsl:with-param name="auto">note</xsl:with-param>
+        <xsl:with-param name="auto">note</xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="makeAnchor">
-	<xsl:with-param name="name" select="$identifier"/>
+        <xsl:with-param name="name" select="$identifier"/>
       </xsl:call-template>
       <span class="noteLabel">
-	<xsl:choose>
-	  <xsl:when test="@n">
-	    <xsl:value-of select="@n"/>
-	  </xsl:when>
-	  <xsl:otherwise>
-	    <xsl:sequence select="tei:i18n('Note')"/>
-	    <xsl:text>: </xsl:text>
-	  </xsl:otherwise>
-	</xsl:choose>
+        <xsl:choose>
+          <xsl:when test="@n">
+            <xsl:value-of select="@n"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:sequence select="tei:i18n('Note')"/>
+            <xsl:text>: </xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
       </span>
       <xsl:apply-templates/>
     </xsl:element>
@@ -995,39 +996,39 @@ of this software, even if advised of the possibility of such damage.
     <xsl:choose>
       <xsl:when test="@type='milestone'">
         <span class="{if (@place) then if (contains(@place,'right'))
-		     then 'notemarginRight' else 'notemarginLeft' else 'notemarginLeft'}">
+                     then 'notemarginRight' else 'notemarginLeft' else 'notemarginLeft'}">
           <xsl:call-template name="makeAnchor">
             <xsl:with-param name="name" select="$identifier"/>
           </xsl:call-template>
           <xsl:apply-templates/>
-	</span>
+        </span>
       </xsl:when>
       <xsl:when test="parent::tei:item or
-		      parent::tei:cell or
-		      parent::tei:salute or
-		      parent::tei:head/parent::tei:list or 
-		      parent::tei:q/parent::tei:div or 
+                      parent::tei:cell or
+                      parent::tei:salute or
+                      parent::tei:head/parent::tei:list or 
+                      parent::tei:q/parent::tei:div or 
                       parent::tei:div or 
                       parent::tei:l or
-		      parent::tei:bibl/parent::tei:q/parent::tei:epigraph or
-		      parent::tei:bibl/parent::tei:q/parent::tei:p
-		       ">
+                      parent::tei:bibl/parent::tei:q/parent::tei:epigraph or
+                      parent::tei:bibl/parent::tei:q/parent::tei:p
+                       ">
         <div class="{if (@place) then if (contains(@place,'right'))
-		     then 'notemarginRight' else 'notemarginLeft' else 'notemarginLeft'}">
+                     then 'notemarginRight' else 'notemarginLeft' else 'notemarginLeft'}">
           <xsl:call-template name="makeAnchor">
             <xsl:with-param name="name" select="$identifier"/>
           </xsl:call-template>
           <xsl:apply-templates/>
-	</div>
+        </div>
       </xsl:when>
       <xsl:when test="not(parent::tei:p or parent::tei:head)">
         <span class="{if (@place) then if (contains(@place,'right'))
-		     then 'notemarginRight' else 'notemarginLeft' else 'notemarginLeft'}">
+                     then 'notemarginRight' else 'notemarginLeft' else 'notemarginLeft'}">
           <xsl:call-template name="makeAnchor">
             <xsl:with-param name="name" select="$identifier"/>
           </xsl:call-template>
           <xsl:apply-templates/>
-	</span>
+        </span>
       </xsl:when>
       <xsl:when test="@place='margin' and parent::tei:hi and not(*)">
         <aside class="note{@place}">
@@ -1035,7 +1036,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:with-param name="name" select="$identifier"/>
           </xsl:call-template>
           <xsl:apply-templates/>
-	</aside>
+        </aside>
       </xsl:when>
       <xsl:when test="*[not(tei:isInline(.))]">
         <aside class="note{@place}">
@@ -1043,7 +1044,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:with-param name="name" select="$identifier"/>
           </xsl:call-template>
           <xsl:apply-templates/>
-	</aside>
+        </aside>
       </xsl:when>
       <xsl:when test="tokenize(@place,' ')=('margin','marginRight','margin-right','margin_right')">
         <aside class="notemarginRight">
@@ -1051,7 +1052,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:with-param name="name" select="$identifier"/>
           </xsl:call-template>
           <xsl:apply-templates/>
-	</aside>
+        </aside>
       </xsl:when>
       <xsl:when test="tokenize(@place,' ')=('margin','marginLeft','margin-left','margin_left')">
         <aside class="notemarginLeft">
@@ -1059,7 +1060,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:with-param name="name" select="$identifier"/>
           </xsl:call-template>
           <xsl:apply-templates/>
-	</aside>
+        </aside>
       </xsl:when>
       <xsl:otherwise>
         <aside class="notemarginLeft {@place}">
@@ -1083,7 +1084,7 @@ of this software, even if advised of the possibility of such damage.
       <xsl:when test="ancestor::tei:group"/>
       <xsl:when test="ancestor::tei:floatingText"/>
       <xsl:when
-	  test="ancestor::tei:div[tei:keepDivOnPage(.)]">
+          test="ancestor::tei:div[tei:keepDivOnPage(.)]">
         <xsl:call-template name="makeaNote"/>
       </xsl:when>
       <xsl:when test="not(ancestor::tei:div or ancestor::tei:div1)">
@@ -1102,17 +1103,17 @@ of this software, even if advised of the possibility of such damage.
       <xsl:when test="ancestor::tei:floatingText"/>
       <xsl:when test="number($splitLevel)=-1"/>
       <xsl:when test="tei:isEndNote(.) or tei:isFootNote(.) or
-		      $autoEndNotes='true'">
+                      $autoEndNotes='true'">
         <xsl:variable name="parent">
-	  <xsl:for-each select="ancestor::tei:*[local-name()='div'
-	    or local-name()='div1'
-	    or local-name()='div2'
-	    or local-name()='div3'
-	    or local-name()='div4'
-	    or local-name()='div5'
-	    or local-name()='div6'][1]">
-	    <xsl:call-template name="locateParentDiv"/>
-	  </xsl:for-each>
+          <xsl:for-each select="ancestor::tei:*[local-name()='div'
+            or local-name()='div1'
+            or local-name()='div2'
+            or local-name()='div3'
+            or local-name()='div4'
+            or local-name()='div5'
+            or local-name()='div6'][1]">
+            <xsl:call-template name="locateParentDiv"/>
+          </xsl:for-each>
         </xsl:variable>
         <xsl:if test="$whence = $parent">
           <xsl:call-template name="makeaNote"/>
@@ -1188,63 +1189,63 @@ of this software, even if advised of the possibility of such damage.
       <xsl:when test="$pagebreakStyle='active'">
         <div>
           <xsl:call-template name="makeRendition">
-	    <xsl:with-param  name="default" select="'pagebreak'"/>
-	  </xsl:call-template>
+            <xsl:with-param  name="default" select="'pagebreak'"/>
+          </xsl:call-template>
         </div>
       </xsl:when>
       <xsl:when test="$pagebreakStyle='none'"/>
       <xsl:otherwise>
         <xsl:element name="{if (parent::tei:body or parent::tei:front
-			   or parent::tei:div  or parent::tei:back or
-			   parent::tei:lg or parent::tei:group) then 'div' else 'span'}">
+                           or parent::tei:div  or parent::tei:back or
+                           parent::tei:lg or parent::tei:group) then 'div' else 'span'}">
           <xsl:call-template name="makeRendition">
-	    <xsl:with-param  name="default" select="'pagebreak'"/>
-	  </xsl:call-template>
+            <xsl:with-param  name="default" select="'pagebreak'"/>
+          </xsl:call-template>
           <xsl:call-template name="makeAnchor"/>
-	  <xsl:variable name="Words">
-	    <xsl:text>[</xsl:text>
-	    <xsl:sequence select="if (self::tei:gb) then tei:i18n('gathering') else tei:i18n('page')"/>
-	    <xsl:if test="@n">
-	      <xsl:text> </xsl:text>
-	      <xsl:value-of select="@n"/>
-	    </xsl:if>
-	    <xsl:text>]</xsl:text>
-	  </xsl:variable>
-	  <xsl:choose>
-	    <xsl:when test="$pagebreakStyle='simple'">
-	      <xsl:copy-of select="$Words"/>
-	    </xsl:when>
-	    <xsl:when test="rend='none'"/>
-	    <xsl:when test="$pagebreakStyle='display' and @facs">
-	      <div class="facsimage">
-		<img src="{@facs}"/>
-	      </div>
-	    </xsl:when>
-	    <xsl:when test="starts-with(@facs,'unknown:')">
-	      <xsl:copy-of select="$Words"/>
-	    </xsl:when>
-	    <xsl:when test="@facs">
-	      <xsl:variable name="IMG">
-		<xsl:choose>
-		  <xsl:when test="starts-with(@facs,'#')">
-		    <xsl:for-each select="id(substring(@facs,2))">
-		      <xsl:value-of select="tei:graphic[1]/tei:resolveURI(.,@url)"/>
-		    </xsl:for-each>
-		  </xsl:when>
-		  <xsl:otherwise>
-		    <xsl:value-of select="tei:resolveURI(.,@facs)"/>
-		  </xsl:otherwise>
-		</xsl:choose>
-	      </xsl:variable>
-	      <a href="{$IMG}">
-		<xsl:copy-of select="$Words"/>
-	      </a>
-	    </xsl:when>
-	    <xsl:otherwise>
-	      <xsl:copy-of select="$Words"/>
-	    </xsl:otherwise>
-	  </xsl:choose>
-	</xsl:element>
+          <xsl:variable name="Words">
+            <xsl:text>[</xsl:text>
+            <xsl:sequence select="if (self::tei:gb) then tei:i18n('gathering') else tei:i18n('page')"/>
+            <xsl:if test="@n">
+              <xsl:text> </xsl:text>
+              <xsl:value-of select="@n"/>
+            </xsl:if>
+            <xsl:text>]</xsl:text>
+          </xsl:variable>
+          <xsl:choose>
+            <xsl:when test="$pagebreakStyle='simple'">
+              <xsl:copy-of select="$Words"/>
+            </xsl:when>
+            <xsl:when test="rend='none'"/>
+            <xsl:when test="$pagebreakStyle='display' and @facs">
+              <div class="facsimage">
+                <img src="{@facs}"/>
+              </div>
+            </xsl:when>
+            <xsl:when test="starts-with(@facs,'unknown:')">
+              <xsl:copy-of select="$Words"/>
+            </xsl:when>
+            <xsl:when test="@facs">
+              <xsl:variable name="IMG">
+                <xsl:choose>
+                  <xsl:when test="starts-with(@facs,'#')">
+                    <xsl:for-each select="id(substring(@facs,2))">
+                      <xsl:value-of select="tei:graphic[1]/tei:resolveURI(.,@url)"/>
+                    </xsl:for-each>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:value-of select="tei:resolveURI(.,@facs)"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:variable>
+              <a href="{$IMG}">
+                <xsl:copy-of select="$Words"/>
+              </a>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:copy-of select="$Words"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:element>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -1262,19 +1263,19 @@ of this software, even if advised of the possibility of such damage.
               <xsl:element name="{$wrapperElement}">
                 <xsl:for-each select="..">
                   <xsl:call-template name="makeRendition">
-		    <xsl:with-param name="default">false</xsl:with-param>
-		  </xsl:call-template>
-		  <xsl:attribute name="id">
-		    <xsl:choose>
-		      <xsl:when test="@xml:id">
-			<xsl:value-of select="@xml:id"/>
-			<xsl:text>continued</xsl:text>
-		      </xsl:when>
-		      <xsl:otherwise>
-			<xsl:text>false</xsl:text>
-		      </xsl:otherwise>
+                    <xsl:with-param name="default">false</xsl:with-param>
+                  </xsl:call-template>
+                  <xsl:attribute name="id">
+                    <xsl:choose>
+                      <xsl:when test="@xml:id">
+                        <xsl:value-of select="@xml:id"/>
+                        <xsl:text>continued</xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:text>false</xsl:text>
+                      </xsl:otherwise>
                       </xsl:choose>
-		  </xsl:attribute>
+                  </xsl:attribute>
                 </xsl:for-each>
                 <xsl:apply-templates select="current-group() except ."/>
               </xsl:element>
@@ -1283,8 +1284,8 @@ of this software, even if advised of the possibility of such damage.
               <xsl:element name="{$wrapperElement}">
                 <xsl:for-each select="..">
                   <xsl:call-template name="makeRendition">
-		    <xsl:with-param name="default">false</xsl:with-param>
-		  </xsl:call-template>
+                    <xsl:with-param name="default">false</xsl:with-param>
+                  </xsl:call-template>
                 </xsl:for-each>
                 <xsl:apply-templates select="current-group()"/>
               </xsl:element>
@@ -1293,29 +1294,29 @@ of this software, even if advised of the possibility of such damage.
         </xsl:for-each-group>
       </xsl:when>
       <xsl:when test="teix:egXML or ancestor::tei:head or $wrapperElement='span'">
-	<xsl:element name="{$wrapperElement}">
-	  <xsl:call-template name="makeRendition">
-	    <xsl:with-param name="default">p</xsl:with-param>
-	  </xsl:call-template>
-	  <xsl:if test="@xml:id or $generateParagraphIDs='true'">
-	      <xsl:call-template name="makeAnchor"/>
-	  </xsl:if>
-	  <xsl:if test="$numberParagraphs='true'">
-	    <xsl:call-template name="numberParagraph"/>
-	  </xsl:if>
-	  <xsl:apply-templates/>
-	</xsl:element>
+        <xsl:element name="{$wrapperElement}">
+          <xsl:call-template name="makeRendition">
+            <xsl:with-param name="default">p</xsl:with-param>
+          </xsl:call-template>
+          <xsl:if test="@xml:id or $generateParagraphIDs='true'">
+              <xsl:call-template name="makeAnchor"/>
+          </xsl:if>
+          <xsl:if test="$numberParagraphs='true'">
+            <xsl:call-template name="numberParagraph"/>
+          </xsl:if>
+          <xsl:apply-templates/>
+        </xsl:element>
       </xsl:when>
       <xsl:otherwise>
-	<xsl:call-template name="splitHTMLBlocks">
-	  <xsl:with-param name="element">p</xsl:with-param>
-	  <xsl:with-param name="content">
-	    <xsl:if test="$numberParagraphs='true'">
-	      <xsl:call-template name="numberParagraph"/>
-	    </xsl:if>
-	    <xsl:apply-templates/>
-	  </xsl:with-param>
-	</xsl:call-template>
+        <xsl:call-template name="splitHTMLBlocks">
+          <xsl:with-param name="element">p</xsl:with-param>
+          <xsl:with-param name="content">
+            <xsl:if test="$numberParagraphs='true'">
+              <xsl:call-template name="numberParagraph"/>
+            </xsl:if>
+            <xsl:apply-templates/>
+          </xsl:with-param>
+        </xsl:call-template>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -1326,7 +1327,7 @@ of this software, even if advised of the possibility of such damage.
     </doc>
     <xsl:template name="numberParagraph">
       <span class="numberParagraph">
-	<xsl:number/>
+        <xsl:number/>
     </span>
   </xsl:template>
   <xsl:template match="tei:q|tei:said">
@@ -1336,15 +1337,15 @@ of this software, even if advised of the possibility of such damage.
       </xsl:when>
       <xsl:when test="(not(parent::tei:p/text()) and count(parent::tei:p/*)=1) or tei:floatingText or not(tei:isInline(.))">
         <div>
-	  <xsl:call-template name="makeRendition">
-	    <xsl:with-param name="auto">blockquote</xsl:with-param>
-	  </xsl:call-template>
+          <xsl:call-template name="makeRendition">
+            <xsl:with-param name="auto">blockquote</xsl:with-param>
+          </xsl:call-template>
           <xsl:apply-templates/>
         </div>
       </xsl:when>
       <xsl:otherwise>
         <span>
-	  <xsl:call-template name="makeRendition"/>
+          <xsl:call-template name="makeRendition"/>
           <xsl:call-template name="makeQuote"/>
         </span>
       </xsl:otherwise>
@@ -1357,24 +1358,24 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:quote">
     <xsl:choose>
       <xsl:when test="parent::tei:cit[tei:match(@rend,'display')] or
-		      parent::tei:cit and (tei:p or tei:l)">
+                      parent::tei:cit and (tei:p or tei:l)">
         <xsl:call-template name="makeBlock">
-	  <xsl:with-param name="style">citquote</xsl:with-param>
-	</xsl:call-template>
+          <xsl:with-param name="style">citquote</xsl:with-param>
+        </xsl:call-template>
       </xsl:when>
       <xsl:when test="tei:list">
         <xsl:call-template name="makeBlock">
-	  <xsl:with-param name="style">citquote</xsl:with-param>
-	</xsl:call-template>
+          <xsl:with-param name="style">citquote</xsl:with-param>
+        </xsl:call-template>
       </xsl:when>
       <xsl:when test="not(tei:isInline(.))">
         <blockquote>
           <xsl:call-template name="makeRendition"/>
-	  <xsl:if test="@xml:id">
-	    <xsl:attribute name="id">
-	      <xsl:value-of select="@xml:id"/>
-	    </xsl:attribute>
-	  </xsl:if>
+          <xsl:if test="@xml:id">
+            <xsl:attribute name="id">
+              <xsl:value-of select="@xml:id"/>
+            </xsl:attribute>
+          </xsl:if>
           <xsl:choose>
             <xsl:when test="$outputTarget='html5'">
               <xsl:apply-templates/>
@@ -1391,9 +1392,9 @@ of this software, even if advised of the possibility of such damage.
         </blockquote>
       </xsl:when>
       <xsl:otherwise>
-	<span>
-	  <xsl:call-template name="makeRendition"/>
-	  <xsl:call-template name="makeQuote"/>
+        <span>
+          <xsl:call-template name="makeRendition"/>
+          <xsl:call-template name="makeQuote"/>
         </span>
       </xsl:otherwise>
     </xsl:choose>
@@ -1416,24 +1417,24 @@ of this software, even if advised of the possibility of such damage.
   </doc>
   <xsl:template match="tei:seg">
     <xsl:variable name="container" select="if (tei:render-superscript(.)) then 'sup' 
-					   else if (tei:render-subscript(.)) then 'sub' 
-					   else if (tei:match(@rend,'code')) then 'code' else 'span'"/>
+                                           else if (tei:render-subscript(.)) then 'sub' 
+                                           else if (tei:match(@rend,'code')) then 'code' else 'span'"/>
     <xsl:element name="{$container}">
       <xsl:choose>
         <xsl:when test="@type">
-	  <xsl:call-template name="makeLang"/>
+          <xsl:call-template name="makeLang"/>
           <xsl:attribute name="class">
             <xsl:value-of select="@type"/>
           </xsl:attribute>
         </xsl:when>
-	<xsl:otherwise>
-	  <xsl:call-template name="makeRendition">
-	    <xsl:with-param name="default">false</xsl:with-param>
-	  </xsl:call-template>
-	</xsl:otherwise>
+        <xsl:otherwise>
+          <xsl:call-template name="makeRendition">
+            <xsl:with-param name="default">false</xsl:with-param>
+          </xsl:call-template>
+        </xsl:otherwise>
       </xsl:choose>
       <xsl:if test="@xml:id">
-	<xsl:call-template name="makeAnchor"/>
+        <xsl:call-template name="makeAnchor"/>
       </xsl:if>
       <xsl:apply-templates/>
     </xsl:element>
@@ -1537,9 +1538,9 @@ of this software, even if advised of the possibility of such damage.
   </doc>
   <xsl:template name="printNotes">
     <xsl:if test="key('FOOTNOTES',1) or
-		  key('ENDNOTES',1) or  
-		  ($autoEndNotes='true' and key('ALLNOTES',1))
-		  or (self::tei:floatingText and .//tei:note)">
+                  key('ENDNOTES',1) or  
+                  ($autoEndNotes='true' and key('ALLNOTES',1))
+                  or (self::tei:floatingText and .//tei:note)">
       <xsl:choose>
         <xsl:when test="$footnoteFile='true'">
           <xsl:variable name="BaseFile">
@@ -1560,12 +1561,12 @@ of this software, even if advised of the possibility of such damage.
           <xsl:result-document doctype-public="{$doctypePublic}" doctype-system="{$doctypeSystem}" encoding="{$outputEncoding}" href="{$outName}" method="{$outputMethod}">
             <html>
               <xsl:call-template name="addLangAtt"/>
-	      <xsl:variable name="pagetitle">
-		<xsl:sequence select="tei:generateTitle(.)"/>
+              <xsl:variable name="pagetitle">
+                <xsl:sequence select="tei:generateTitle(.)"/>
                   <xsl:text>: </xsl:text>
                   <xsl:sequence select="tei:i18n('noteHeading')"/>
-	      </xsl:variable>
-	      <xsl:sequence select="tei:htmlHead($pagetitle,1)"/>
+              </xsl:variable>
+              <xsl:sequence select="tei:htmlHead($pagetitle,1)"/>
               <body>
                 <xsl:call-template name="bodyMicroData"/>
                 <xsl:call-template name="bodyJavascriptHook"/>
@@ -1573,7 +1574,7 @@ of this software, even if advised of the possibility of such damage.
                 <div class="stdheader autogenerated">
                   <xsl:call-template name="stdheader">
                     <xsl:with-param name="title">
-		      <xsl:sequence select="tei:generateTitle(.)"/>
+                      <xsl:sequence select="tei:generateTitle(.)"/>
                       <xsl:text>: </xsl:text>
                       <xsl:sequence select="tei:i18n('noteHeading')"/>
                     </xsl:with-param>
@@ -1582,25 +1583,25 @@ of this software, even if advised of the possibility of such damage.
                 <div class="notes">
                   <xsl:choose>
                     <xsl:when test="$autoEndNotes='true'">
-		      <div class="noteHeading">
-			<xsl:sequence select="tei:i18n('noteHeading')"/>
-		      </div>
+                      <div class="noteHeading">
+                        <xsl:sequence select="tei:i18n('noteHeading')"/>
+                      </div>
                       <xsl:apply-templates mode="printnotes" select="key('ALLNOTES',1)"/>
                     </xsl:when>
-		    <xsl:otherwise>
-		      <xsl:if test="key('FOOTNOTES',1)">
-			<div class="noteHeading footnotes">
-			  <xsl:sequence select="tei:i18n('noteHeading')"/>
-			</div>
-			<xsl:apply-templates mode="printnotes" select="key('FOOTNOTES',1)"/>
-		      </xsl:if>
-		      <xsl:if test="key('ENDNOTES',1)">
-			<div class="noteHeading endnotes">
-			  <xsl:sequence select="tei:i18n('noteHeading')"/>
-			</div>
-			<xsl:apply-templates mode="printnotes" select="key('ENDNOTES',1)"/>
-		      </xsl:if>
-		    </xsl:otherwise>
+                    <xsl:otherwise>
+                      <xsl:if test="key('FOOTNOTES',1)">
+                        <div class="noteHeading footnotes">
+                          <xsl:sequence select="tei:i18n('noteHeading')"/>
+                        </div>
+                        <xsl:apply-templates mode="printnotes" select="key('FOOTNOTES',1)"/>
+                      </xsl:if>
+                      <xsl:if test="key('ENDNOTES',1)">
+                        <div class="noteHeading endnotes">
+                          <xsl:sequence select="tei:i18n('noteHeading')"/>
+                        </div>
+                        <xsl:apply-templates mode="printnotes" select="key('ENDNOTES',1)"/>
+                      </xsl:if>
+                    </xsl:otherwise>
                   </xsl:choose>
                 </div>
                 <xsl:call-template name="stdfooter"/>
@@ -1619,77 +1620,77 @@ of this software, even if advised of the possibility of such damage.
           </xsl:variable>
            <xsl:variable name="NOTES">
             <xsl:choose>
-	      <xsl:when test="self::tei:floatingText">
-		<xsl:variable name="outer" select="generate-id(.)"/>
-		<xsl:for-each select=".//tei:note[tei:isEndNote(.) or
-				      tei:isFootNote(.)]">
-		  <xsl:choose>
-		    <xsl:when test="count(ancestor-or-self::tei:floatingText)=1">
-		      <xsl:call-template name="makeaNote"/>
-		    </xsl:when>
-		    <xsl:when test="generate-id(ancestor-or-self::tei:floatingText[1])=$outer">
-		      <xsl:call-template name="makeaNote"/>
-		    </xsl:when>
-		  </xsl:choose>
-		</xsl:for-each>
-	      </xsl:when>
+              <xsl:when test="self::tei:floatingText">
+                <xsl:variable name="outer" select="generate-id(.)"/>
+                <xsl:for-each select=".//tei:note[tei:isEndNote(.) or
+                                      tei:isFootNote(.)]">
+                  <xsl:choose>
+                    <xsl:when test="count(ancestor-or-self::tei:floatingText)=1">
+                      <xsl:call-template name="makeaNote"/>
+                    </xsl:when>
+                    <xsl:when test="generate-id(ancestor-or-self::tei:floatingText[1])=$outer">
+                      <xsl:call-template name="makeaNote"/>
+                    </xsl:when>
+                  </xsl:choose>
+                </xsl:for-each>
+              </xsl:when>
               <xsl:when test="self::tei:TEI">
                 <xsl:choose>
                   <xsl:when test="$autoEndNotes='true'">
-		    <div class="noteHeading">
-		      <xsl:sequence select="tei:i18n('noteHeading')"/>
-		    </div>
+                    <div class="noteHeading">
+                      <xsl:sequence select="tei:i18n('noteHeading')"/>
+                    </div>
                     <xsl:apply-templates mode="printallnotes" select="key('ALLNOTES',1)"/>
                   </xsl:when>
                   <xsl:otherwise>
-		      <xsl:if test="key('FOOTNOTES',1)">
-			<div class="noteHeading">
-			  <xsl:sequence select="tei:i18n('noteHeading')"/>
-			</div>
-			<xsl:apply-templates mode="printallnotes" select="key('FOOTNOTES',1)"/>
-		      </xsl:if>
-		      <xsl:if test="key('ENDNOTES',1)">
-			<div class="noteHeading">
-			  <xsl:sequence select="tei:i18n('noteHeading')"/>
-			</div>
-			<xsl:apply-templates mode="printallnotes" select="key('ENDNOTES',1)"/>
-		      </xsl:if>
+                      <xsl:if test="key('FOOTNOTES',1)">
+                        <div class="noteHeading">
+                          <xsl:sequence select="tei:i18n('noteHeading')"/>
+                        </div>
+                        <xsl:apply-templates mode="printallnotes" select="key('FOOTNOTES',1)"/>
+                      </xsl:if>
+                      <xsl:if test="key('ENDNOTES',1)">
+                        <div class="noteHeading">
+                          <xsl:sequence select="tei:i18n('noteHeading')"/>
+                        </div>
+                        <xsl:apply-templates mode="printallnotes" select="key('ENDNOTES',1)"/>
+                      </xsl:if>
                   </xsl:otherwise>
                 </xsl:choose>
               </xsl:when>
-	      <xsl:when test="self::tei:text and $splitLevel=0">
-		<div class="noteHeading">
-		  <xsl:sequence select="tei:i18n('noteHeading')"/>
-		</div>
-		<xsl:for-each select="tei:front|tei:body|tei:back">
-		  <xsl:for-each
-		      select=".//tei:note[tei:isEndNote(.) or
-			      tei:isFootNote(.)]">
-		    <xsl:choose>
-		      <xsl:when test="ancestor::tei:floatingText"/>
-		      <xsl:otherwise>
-			<xsl:call-template name="makeaNote"/>
-		      </xsl:otherwise>
-		    </xsl:choose>		      
-		  </xsl:for-each>
-		</xsl:for-each>
-	      </xsl:when>
+              <xsl:when test="self::tei:text and $splitLevel=0">
+                <div class="noteHeading">
+                  <xsl:sequence select="tei:i18n('noteHeading')"/>
+                </div>
+                <xsl:for-each select="tei:front|tei:body|tei:back">
+                  <xsl:for-each
+                      select=".//tei:note[tei:isEndNote(.) or
+                              tei:isFootNote(.)]">
+                    <xsl:choose>
+                      <xsl:when test="ancestor::tei:floatingText"/>
+                      <xsl:otherwise>
+                        <xsl:call-template name="makeaNote"/>
+                      </xsl:otherwise>
+                    </xsl:choose>                     
+                  </xsl:for-each>
+                </xsl:for-each>
+              </xsl:when>
               <xsl:when test="parent::tei:group and tei:group">
-	      </xsl:when>
+              </xsl:when>
               <xsl:otherwise>
-		<div class="noteHeading">
-		  <xsl:sequence select="tei:i18n('noteHeading')"/>
-		</div>
+                <div class="noteHeading">
+                  <xsl:sequence select="tei:i18n('noteHeading')"/>
+                </div>
                 <xsl:apply-templates mode="printnotes" select=".//tei:note">
                   <xsl:with-param name="whence" select="$me"/>
                 </xsl:apply-templates>
               </xsl:otherwise>
             </xsl:choose>
           </xsl:variable>
-	  <xsl:variable name="where" select="name()"/>
+          <xsl:variable name="where" select="name()"/>
           <xsl:for-each select="$NOTES">
             <xsl:if test="html:div[@class='note']">
-	      <xsl:comment>Notes in [<xsl:value-of select="$where"/>]</xsl:comment>
+              <xsl:comment>Notes in [<xsl:value-of select="$where"/>]</xsl:comment>
               <div class="notes">
                 <xsl:copy-of select="*|comment()"/>
               </div>
@@ -1738,10 +1739,10 @@ of this software, even if advised of the possibility of such damage.
         <xsl:attribute name="id" select="@xml:id"/>
       </xsl:when>
       <xsl:when test="self::tei:anchor">
-	<a>
-	  <xsl:attribute name="id"
-		       select="concat($masterFile,'-',local-name(.),'-',generate-id())"/>
-	</a>
+        <a>
+          <xsl:attribute name="id"
+                       select="concat($masterFile,'-',local-name(.),'-',generate-id())"/>
+        </a>
       </xsl:when>
       <xsl:otherwise>
         <xsl:attribute name="id" select="concat($masterFile,'-',local-name(.),'-',generate-id())"/>
@@ -1754,10 +1755,10 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:soCalled">
     <xsl:choose>
       <xsl:when test="@rend or @rendition or @style">
-	<span>
-	  <xsl:call-template name="makeRendition"/>
-	  <xsl:apply-templates/>
-	</span>
+        <span>
+          <xsl:call-template name="makeRendition"/>
+          <xsl:apply-templates/>
+        </span>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="$preQuote"/>
@@ -1801,42 +1802,42 @@ of this software, even if advised of the possibility of such damage.
     <xsl:if test="not(following-sibling::tei:monogr/tei:title[@level='m']) and $refId!=''">
       <xsl:text> </xsl:text>
       <xsl:if test="following-sibling::tei:monogr/tei:imprint/tei:date">
-	<xsl:value-of select="following-sibling::tei:monogr/tei:imprint/tei:date"/>
-	<xsl:text>. </xsl:text>
+        <xsl:value-of select="following-sibling::tei:monogr/tei:imprint/tei:date"/>
+        <xsl:text>. </xsl:text>
       </xsl:if>
       <xsl:choose>
-	<xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[1]">
-	  <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[1], ',')"/>
-	</xsl:when>
-	<xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][1]">
-	  <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][1], ',')"/>
-	</xsl:when>
+        <xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[1]">
+          <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[1], ',')"/>
+        </xsl:when>
+        <xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][1]">
+          <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][1], ',')"/>
+        </xsl:when>
       </xsl:choose>
       <xsl:choose>
-	<xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[3]">
-	  <xsl:text>, </xsl:text>
-	  <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[2], ',')"/>
-	  <xsl:text>, and </xsl:text>
-	</xsl:when>
-	<xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][3]">
-	  <xsl:text>, </xsl:text>
-	  <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][2], ',')"/>
-	  <xsl:text>, and </xsl:text>
-	</xsl:when>
-	<xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[2]">
-	  <xsl:text> and </xsl:text>
-	  <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[2], ',')"/>
-	</xsl:when>
-	<xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][2]">
-	  <xsl:text> and </xsl:text>
-	  <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][2], ',')"/>
-	</xsl:when>
+        <xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[3]">
+          <xsl:text>, </xsl:text>
+          <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[2], ',')"/>
+          <xsl:text>, and </xsl:text>
+        </xsl:when>
+        <xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][3]">
+          <xsl:text>, </xsl:text>
+          <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][2], ',')"/>
+          <xsl:text>, and </xsl:text>
+        </xsl:when>
+        <xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[2]">
+          <xsl:text> and </xsl:text>
+          <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[2], ',')"/>
+        </xsl:when>
+        <xsl:when test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][2]">
+          <xsl:text> and </xsl:text>
+          <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][2], ',')"/>
+        </xsl:when>
       </xsl:choose>
       <xsl:if test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[3]">
-	<xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[3], ',')"/>
+        <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:author[3], ',')"/>
       </xsl:if>
       <xsl:if test="ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][3]">
-	<xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][3], ',')"/>
+        <xsl:value-of select="substring-before(ancestor::tei:listBibl/tei:biblStruct[@xml:id=$refId]/tei:monogr/tei:editor[@role='editor'][3], ',')"/>
       </xsl:if>
       <xsl:text> </xsl:text>
       <xsl:value-of select="following-sibling::tei:monogr/tei:imprint/tei:biblScope[@type='pp']"/>
@@ -1850,76 +1851,76 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:monogr" mode="mla">
     <xsl:choose>
       <xsl:when test="preceding-sibling::tei:analytic">
-	<xsl:choose>
-	  <xsl:when test="tei:author = parent::tei:biblStruct/tei:analytic/tei:author">
-	    <xsl:if test="tei:author[2]">
-	      <xsl:apply-templates select="tei:author"/>
-	    </xsl:if>
-	    <xsl:apply-templates select="tei:title"/>
-	    <xsl:if test="tei:edition"><xsl:apply-templates select="tei:edition"/></xsl:if>
-	    <xsl:apply-templates select="tei:editor[@role='editor']"/>
-	    <xsl:if test="tei:editor[@role='translator']">
-	      <xsl:apply-templates select="tei:editor[@role='translator']"/>
-	    </xsl:if>
-	  </xsl:when>
-	  <xsl:otherwise>
-	    <xsl:apply-templates select="tei:author"/>
-	    <xsl:apply-templates select="tei:title"/>
-	    <xsl:if test="tei:edition"><xsl:apply-templates select="tei:edition"/></xsl:if>
-	    <xsl:apply-templates select="tei:editor[@role='editor']"/>
-	    <xsl:if test="tei:editor[@role='translator']">
-	      <xsl:apply-templates select="tei:editor[@role='translator']"/>
-	    </xsl:if>
-	  </xsl:otherwise>
-	</xsl:choose>
+        <xsl:choose>
+          <xsl:when test="tei:author = parent::tei:biblStruct/tei:analytic/tei:author">
+            <xsl:if test="tei:author[2]">
+              <xsl:apply-templates select="tei:author"/>
+            </xsl:if>
+            <xsl:apply-templates select="tei:title"/>
+            <xsl:if test="tei:edition"><xsl:apply-templates select="tei:edition"/></xsl:if>
+            <xsl:apply-templates select="tei:editor[@role='editor']"/>
+            <xsl:if test="tei:editor[@role='translator']">
+              <xsl:apply-templates select="tei:editor[@role='translator']"/>
+            </xsl:if>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates select="tei:author"/>
+            <xsl:apply-templates select="tei:title"/>
+            <xsl:if test="tei:edition"><xsl:apply-templates select="tei:edition"/></xsl:if>
+            <xsl:apply-templates select="tei:editor[@role='editor']"/>
+            <xsl:if test="tei:editor[@role='translator']">
+              <xsl:apply-templates select="tei:editor[@role='translator']"/>
+            </xsl:if>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:when>
       <xsl:when test="tei:editor[@role='editor'] and not(preceding-sibling::tei:analytic) and not(tei:author)">
-	<xsl:apply-templates select="tei:editor[@role='editor']"/>
-	<xsl:apply-templates select="tei:title"/>
-	<xsl:if test="tei:edition"><xsl:apply-templates select="tei:edition"/></xsl:if>
-	<xsl:if test="tei:editor[@role='translator']">
-	  <xsl:apply-templates select="tei:editor[@role='translator']"/>
-	</xsl:if>
+        <xsl:apply-templates select="tei:editor[@role='editor']"/>
+        <xsl:apply-templates select="tei:title"/>
+        <xsl:if test="tei:edition"><xsl:apply-templates select="tei:edition"/></xsl:if>
+        <xsl:if test="tei:editor[@role='translator']">
+          <xsl:apply-templates select="tei:editor[@role='translator']"/>
+        </xsl:if>
       </xsl:when>
       <xsl:otherwise>
-	<xsl:apply-templates select="tei:author"/>
-	<xsl:apply-templates select="tei:title"/>
-	<xsl:if test="tei:edition"><xsl:apply-templates select="tei:edition"/></xsl:if>
-	<xsl:apply-templates select="tei:editor[@role='editor']"/>
-	<xsl:if test="tei:editor[@role='translator']">
-	  <xsl:apply-templates select="tei:editor[@role='translator']"/>
-	</xsl:if>
+        <xsl:apply-templates select="tei:author"/>
+        <xsl:apply-templates select="tei:title"/>
+        <xsl:if test="tei:edition"><xsl:apply-templates select="tei:edition"/></xsl:if>
+        <xsl:apply-templates select="tei:editor[@role='editor']"/>
+        <xsl:if test="tei:editor[@role='translator']">
+          <xsl:apply-templates select="tei:editor[@role='translator']"/>
+        </xsl:if>
       </xsl:otherwise>
     </xsl:choose>
     <xsl:choose>
       <xsl:when test="*//tei:ref/@target and not(contains(*//tei:ref/@target, '#'))">
-	<xsl:if test="tei:imprint/tei:date[@type='update']"><xsl:value-of select="tei:imprint/tei:date[@type='update']"/></xsl:if>
+        <xsl:if test="tei:imprint/tei:date[@type='update']"><xsl:value-of select="tei:imprint/tei:date[@type='update']"/></xsl:if>
       </xsl:when>
       <xsl:when test="ancestor-or-self::tei:biblStruct/*/tei:title/@level='u'">
-	<xsl:value-of select="tei:imprint"/>
+        <xsl:value-of select="tei:imprint"/>
       </xsl:when>
       <xsl:when test="tei:title/@level='m'">
-	<xsl:if test="tei:imprint/tei:biblScope/@type='vol'">
-	<xsl:value-of select="tei:imprint/tei:biblScope[@type='vol']"/>. </xsl:if>
-	<xsl:choose>
-	  <xsl:when test="tei:imprint/tei:pubPlace"><xsl:value-of select="tei:imprint/tei:pubPlace"/>: </xsl:when>
-	  <xsl:otherwise>[n.p.]: </xsl:otherwise>
-	</xsl:choose>
-	<xsl:choose>
-	  <xsl:when test="tei:imprint/tei:publisher"><xsl:value-of select="tei:imprint/tei:publisher"/>, </xsl:when>
-	  <xsl:otherwise>[n.p.], </xsl:otherwise>
-	</xsl:choose>
-	<xsl:choose>
-	  <xsl:when test="tei:imprint/tei:date"><xsl:value-of select="tei:imprint/tei:date"/>. </xsl:when>
-	  <xsl:otherwise>[n.d.]  </xsl:otherwise>
-	</xsl:choose>
+        <xsl:if test="tei:imprint/tei:biblScope/@type='vol'">
+        <xsl:value-of select="tei:imprint/tei:biblScope[@type='vol']"/>. </xsl:if>
+        <xsl:choose>
+          <xsl:when test="tei:imprint/tei:pubPlace"><xsl:value-of select="tei:imprint/tei:pubPlace"/>: </xsl:when>
+          <xsl:otherwise>[n.p.]: </xsl:otherwise>
+        </xsl:choose>
+        <xsl:choose>
+          <xsl:when test="tei:imprint/tei:publisher"><xsl:value-of select="tei:imprint/tei:publisher"/>, </xsl:when>
+          <xsl:otherwise>[n.p.], </xsl:otherwise>
+        </xsl:choose>
+        <xsl:choose>
+          <xsl:when test="tei:imprint/tei:date"><xsl:value-of select="tei:imprint/tei:date"/>. </xsl:when>
+          <xsl:otherwise>[n.d.]  </xsl:otherwise>
+        </xsl:choose>
       </xsl:when>
       <xsl:when test="tei:title/@level='j'">
-	<xsl:if test="tei:imprint/tei:biblScope/@type='vol'"><xsl:value-of select="tei:imprint/tei:biblScope[@type='vol']"/></xsl:if>
-	<xsl:if test="tei:imprint/tei:biblScope/@type='no'"><xsl:text>.</xsl:text><xsl:value-of select="tei:imprint/tei:biblScope[@type='no']"/></xsl:if>
-	<xsl:if test="tei:imprint/tei:date"><xsl:text>&#10;</xsl:text>(<xsl:value-of select="tei:imprint/tei:date"/>)</xsl:if>
-	<xsl:if test="tei:imprint/tei:biblScope/@type='pp'">: <xsl:value-of select="tei:imprint/tei:biblScope[@type='pp']"/></xsl:if>
-	<xsl:text>. </xsl:text>
+        <xsl:if test="tei:imprint/tei:biblScope/@type='vol'"><xsl:value-of select="tei:imprint/tei:biblScope[@type='vol']"/></xsl:if>
+        <xsl:if test="tei:imprint/tei:biblScope/@type='no'"><xsl:text>.</xsl:text><xsl:value-of select="tei:imprint/tei:biblScope[@type='no']"/></xsl:if>
+        <xsl:if test="tei:imprint/tei:date"><xsl:text>&#10;</xsl:text>(<xsl:value-of select="tei:imprint/tei:date"/>)</xsl:if>
+        <xsl:if test="tei:imprint/tei:biblScope/@type='pp'">: <xsl:value-of select="tei:imprint/tei:biblScope[@type='pp']"/></xsl:if>
+        <xsl:text>. </xsl:text>
       </xsl:when>
     </xsl:choose>
   </xsl:template>

--- a/html/html_core.xsl
+++ b/html/html_core.xsl
@@ -843,11 +843,12 @@ of this software, even if advised of the possibility of such damage.
         <ol class="listBibl">
           <xsl:for-each select="*[not(self::tei:head)]">
             <li>
-              <xsl:call-template name="makeAnchor">
+             <xsl:if test="not(@xml:id)">
+               <xsl:call-template name="makeAnchor">
                 <xsl:with-param name="name">
                   <xsl:apply-templates mode="ident" select="."/>
                 </xsl:with-param>
-              </xsl:call-template>
+              </xsl:call-template></xsl:if>
               <xsl:apply-templates select="."/>
             </li>
           </xsl:for-each>


### PR DESCRIPTION
This PR tackles issue #516: In the transformation to HTML, the `@xml:id` of `listBibl/bibl` elements was being added twice: first in the `<li>` element and then in its `<div>` child. 

My proposal is to just add a condition: If the child of `listBibl` being processed has already an `@xml:id`, do not call the `makeAnchor` template.

I am assigning as reviewers @ebeshero and @sydb because of your participation in the discussion of the original ticket.