### PR TITLE
overridability for docxtotei

### DIFF
--- a/docx/build-from.xml
+++ b/docx/build-from.xml
@@ -25,6 +25,7 @@
 
   <target name="dist" depends="convert,mediadir.check,embeddingdir.check,chartdir.check,picturecopy,embeddingcopy,chartcopy,cleanup"/>
 
+  <!-- you can override templates imported via from.xsl and run ant with -DdocxtoTEI=yourxsl -->
   <property name="docxtoTEI" value="${profiledir}/${profile}/docx/from.xsl"/>
 
   <target name="convert">

--- a/docx/from/docxtotei.xsl
+++ b/docx/from/docxtotei.xsl
@@ -38,7 +38,6 @@
 	  <xsl:import href="omml2mml.xsl"/>
 	  <xsl:import href="pass0.xsl"/>
 	  <xsl:import href="pass2.xsl"/>
-
 	  
 	  <xsl:param name="convertGraphics">true</xsl:param>	  
 	  <xsl:param name="mathMethod">mml</xsl:param>	  

--- a/docx/from/docxtotei.xsl
+++ b/docx/from/docxtotei.xsl
@@ -38,8 +38,7 @@
 	  <xsl:import href="omml2mml.xsl"/>
 	  <xsl:import href="pass0.xsl"/>
 	  <xsl:import href="pass2.xsl"/>
-    <xsl:import href="textruns.xsl"/>
-  
+
 	  
 	  <xsl:param name="convertGraphics">true</xsl:param>	  
 	  <xsl:param name="mathMethod">mml</xsl:param>	  
@@ -55,8 +54,8 @@
 	  <xsl:param name="verbose">false</xsl:param>	  
 	  <xsl:param name="processChangeInformation">false</xsl:param>
 	  <xsl:param name="pageHeight">890</xsl:param>
-	  <xsl:param name="pageWidth">576</xsl:param>
-
+      <xsl:param name="pageWidth">576</xsl:param>
+  
 
 	  <xsl:include href="fields.xsl"/>
 	  <xsl:include href="toc.xsl"/>
@@ -67,8 +66,9 @@
 	  <xsl:include href="paragraphs.xsl"/>
 	  <xsl:include href="tables.xsl"/>
 	  <xsl:include href="wordsections.xsl"/>
-	
-	
+	  <xsl:include href="textruns.xsl"/>
+
+
 	  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" scope="stylesheet" type="stylesheet">
       <desc>
          <p> TEI stylesheet for converting Word docx files to TEI </p>

--- a/docx/from/docxtotei.xsl
+++ b/docx/from/docxtotei.xsl
@@ -55,7 +55,6 @@
 	  <xsl:param name="processChangeInformation">false</xsl:param>
 	  <xsl:param name="pageHeight">890</xsl:param>
       <xsl:param name="pageWidth">576</xsl:param>
-  
 
 	  <xsl:include href="fields.xsl"/>
 	  <xsl:include href="toc.xsl"/>
@@ -65,8 +64,8 @@
 	  <xsl:include href="maths.xsl"/>
 	  <xsl:include href="paragraphs.xsl"/>
 	  <xsl:include href="tables.xsl"/>
-	  <xsl:include href="wordsections.xsl"/>
 	  <xsl:include href="textruns.xsl"/>
+	  <xsl:include href="wordsections.xsl"/>
 
 
 	  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" scope="stylesheet" type="stylesheet">

--- a/docx/from/docxtotei.xsl
+++ b/docx/from/docxtotei.xsl
@@ -38,7 +38,8 @@
 	  <xsl:import href="omml2mml.xsl"/>
 	  <xsl:import href="pass0.xsl"/>
 	  <xsl:import href="pass2.xsl"/>
-	
+    <xsl:import href="textruns.xsl"/>
+  
 	  
 	  <xsl:param name="convertGraphics">true</xsl:param>	  
 	  <xsl:param name="mathMethod">mml</xsl:param>	  
@@ -65,7 +66,6 @@
 	  <xsl:include href="maths.xsl"/>
 	  <xsl:include href="paragraphs.xsl"/>
 	  <xsl:include href="tables.xsl"/>
-	  <xsl:include href="textruns.xsl"/>
 	  <xsl:include href="wordsections.xsl"/>
 	
 	

--- a/docx/from/textruns.xsl
+++ b/docx/from/textruns.xsl
@@ -96,7 +96,11 @@ of this software, even if advised of the possibility of such damage.
     </xsl:template>
 
 
-   <xsl:template name="processTextrun">
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>Creates appropriate elements from word style, calls basicStyles. When word style starts with "TEI " or "tei_" calls elementFromStyle.
+    </desc>
+  </doc>
+  <xsl:template name="processTextrun">
      <xsl:variable name="style">
        <xsl:value-of select="w:rPr/w:rStyle/@w:val"/>
      </xsl:variable>
@@ -128,27 +132,21 @@ of this software, even if advised of the possibility of such damage.
        </xsl:when>
        
        <xsl:when test="starts-with($style,'TEI ')">
-	 <xsl:element name="{substring($style,5)}">
-	   <xsl:call-template name="basicStyles">
-	     <xsl:with-param name="parented">true</xsl:with-param>
-	   </xsl:call-template>
-	 </xsl:element>
+         <xsl:call-template name="elementFromStyle">
+           <xsl:with-param name="style" select="substring($style,5)"/>
+         </xsl:call-template>
        </xsl:when>
 
        <xsl:when test="starts-with($style,'tei_')">
-	 <xsl:element name="{substring($style,5)}">
-	   <xsl:call-template name="basicStyles">
-	     <xsl:with-param name="parented">true</xsl:with-param>
-	   </xsl:call-template>
-	 </xsl:element>
+         <xsl:call-template name="elementFromStyle">
+           <xsl:with-param name="style" select="substring($style,5)"/>
+         </xsl:call-template>
        </xsl:when>
 
 	<xsl:when test="doc-available('../../names.xml') and doc('../../names.xml')//tei:gi[.=$style]">
-	  <xsl:element name="{$style}">
-	   <xsl:call-template name="basicStyles">
-	     <xsl:with-param name="parented">true</xsl:with-param>
-	   </xsl:call-template>
-	  </xsl:element>
+	  <xsl:call-template name="elementFromStyle">
+	    <xsl:with-param name="style" select="$style"/>
+	  </xsl:call-template>
 	</xsl:when>
        
        <xsl:when test="not($style='')">
@@ -166,12 +164,27 @@ of this software, even if advised of the possibility of such damage.
      </xsl:choose>
         
    </xsl:template>
+  
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>Creates an element named $style. $style is the word style name with prefix "TEI " or "tei_" stripped off.
+      Override this method if you need to, for example preprocess $style and call the super.
+    </desc>
+  </doc>
+  <xsl:template name="elementFromStyle">
+    <xsl:param name="style"/>
+    <xsl:element name="{$style}">
+      <xsl:call-template name="basicStyles">
+        <xsl:with-param name="parented">true</xsl:with-param>
+      </xsl:call-template>
+    </xsl:element>    
+  </xsl:template>
     
     <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
       <desc>Look at the Word
       underlying basic formatting. We can ignore the run's font change if 
       a) it's not a special para AND the font is the ISO default, OR 
       b) the font for the run is the same as its parent paragraph.</desc>
+      Param parented is true when calling template created an element.
    </doc>
   <xsl:template name="basicStyles">
     <xsl:param name="parented">false</xsl:param>

--- a/docx/from/textruns.xsl
+++ b/docx/from/textruns.xsl
@@ -166,8 +166,8 @@ of this software, even if advised of the possibility of such damage.
    </xsl:template>
   
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
-    <desc>Creates an element named $style. $style is the word style name with prefix "TEI " or "tei_" stripped off.
-      Override this method if you need to, for example preprocess $style and call the super.
+    <desc>Creates an element named $style and calls basicStyles with parented=true. $style is the word style name with prefix "TEI " or "tei_" stripped off.
+      Override this method if you need to, for example preprocess $style.
     </desc>
   </doc>
   <xsl:template name="elementFromStyle">


### PR DESCRIPTION
docxtotei offers a construct based on style names starting with "TEI " or "tei_".

This PR enables developers to write threir own elementFromStyle template for example to solve style naming problems or to add custom markup.

See: https://bitbucket.org/fryske-akademy/jurisprudentia-frisica/src/master/customDocxToTei.xsl