### PR TITLE
Issue #515: “Attribute” repeated in tagdoc

### DIFF
--- a/Test/expected-results/test15.odd.html
+++ b/Test/expected-results/test15.odd.html
@@ -217,13 +217,65 @@
                 <td class="wovenodd-col1">
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Atributos</span>
                 </td>
-                <td class="wovenodd-col2">Atributos 
-                <div class="table">
-                  <table class="attList" itemprop="table">
-                    <tr itemprop="row">
-                      <td class="odd_label">typo</td>
-                      <td class="odd_value">
-                        <span xml:lang="es" lang="es" itemprop="seg">caracteriza el elemento utilizando una clasificación o tipología funcional.</span>
+                <td class="wovenodd-col2">
+                  <div class="table">
+                    <table class="attList" itemprop="table">
+                      <tr itemprop="row">
+                        <td class="odd_label">typo</td>
+                        <td class="odd_value">
+                          <span xml:lang="es" lang="es" itemprop="seg">caracteriza el elemento utilizando una clasificación o tipología funcional.</span>
+                          <div class="table">
+                            <table class="attDef" itemprop="table">
+                              <tr itemprop="row">
+                                <td class="odd_label">
+                                  <span xml:lang="es" lang="es" class="label" itemprop="hi">Estado</span>
+                                </td>
+                                <td class="odd_value">
+                                  <span xml:lang="es" lang="es" itemprop="seg">Opcional</span>
+                                </td>
+                              </tr>
+                              <tr itemprop="row">
+                                <td class="odd_label">
+                                  <span xml:lang="es" lang="es" class="label" itemprop="hi">Tipo de datos</span>
+                                </td>
+                                <td class="odd_value">teidata.enumerated</td>
+                              </tr>
+                              <tr itemprop="row">
+                                <td colspan="2">
+                                  <div id="index.xml-egXML-d33e505" class="pre egXML_valid">
+                                  <span class="element">&lt;div 
+                                  <span class="attribute">typ</span>="
+                                  <span class="attributevalue">verse</span>"&gt;</span> 
+                                  <span class="element">&lt;head&gt;</span>Night in Tarras
+                                  <span class="element">&lt;/head&gt;</span> 
+                                  <span class="element">&lt;lg 
+                                  <span class="attribute">type</span>="
+                                  <span class="attributevalue">stanza</span>"&gt;</span>  
+                                  <span class="element">&lt;l&gt;</span>At evening tramping on the hot white road
+                                  <span class="element">&lt;/l&gt;</span>  
+                                  <span class="element">&lt;l&gt;</span>…
+                                  <span class="element">&lt;/l&gt;</span> 
+                                  <span class="element">&lt;/lg&gt;</span> 
+                                  <span class="element">&lt;lg 
+                                  <span class="attribute">type</span>="
+                                  <span class="attributevalue">stanza</span>"&gt;</span>  
+                                  <span class="element">&lt;l&gt;</span>A wind sprang up from nowhere as the sky
+                                  <span class="element">&lt;/l&gt;</span>  
+                                  <span class="element">&lt;l&gt;</span>…
+                                  <span class="element">&lt;/l&gt;</span> 
+                                  <span class="element">&lt;/lg&gt;</span>
+                                  <span class="element">&lt;/div&gt;</span></div>
+                                </td>
+                              </tr>
+                            </table>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr itemprop="row">
+                        <td class="odd_label">subtype</td>
+                        <td class="odd_value">(
+                        <span xml:lang="en" lang="en" itemprop="seg">subtype</span>) 
+                        <span xml:lang="es" lang="es" itemprop="seg">proporciona, si es necesario, una subcategorización del elemento.</span>
                         <div class="table">
                           <table class="attDef" itemprop="table">
                             <tr itemprop="row">
@@ -241,72 +293,21 @@
                               <td class="odd_value">teidata.enumerated</td>
                             </tr>
                             <tr itemprop="row">
-                              <td colspan="2">
-                                <div id="index.xml-egXML-d33e506" class="pre egXML_valid">
-                                <span class="element">&lt;div 
-                                <span class="attribute">typ</span>="
-                                <span class="attributevalue">verse</span>"&gt;</span> 
-                                <span class="element">&lt;head&gt;</span>Night in Tarras
-                                <span class="element">&lt;/head&gt;</span> 
-                                <span class="element">&lt;lg 
-                                <span class="attribute">type</span>="
-                                <span class="attributevalue">stanza</span>"&gt;</span>  
-                                <span class="element">&lt;l&gt;</span>At evening tramping on the hot white road
-                                <span class="element">&lt;/l&gt;</span>  
-                                <span class="element">&lt;l&gt;</span>…
-                                <span class="element">&lt;/l&gt;</span> 
-                                <span class="element">&lt;/lg&gt;</span> 
-                                <span class="element">&lt;lg 
-                                <span class="attribute">type</span>="
-                                <span class="attributevalue">stanza</span>"&gt;</span>  
-                                <span class="element">&lt;l&gt;</span>A wind sprang up from nowhere as the sky
-                                <span class="element">&lt;/l&gt;</span>  
-                                <span class="element">&lt;l&gt;</span>…
-                                <span class="element">&lt;/l&gt;</span> 
-                                <span class="element">&lt;/lg&gt;</span>
-                                <span class="element">&lt;/div&gt;</span></div>
+                              <td class="wovenodd-col1">
+                                <span xml:lang="es" lang="es" class="label" itemprop="hi">Nota</span>
+                              </td>
+                              <td class="wovenodd-col2">
+                                <p>El atributo 
+                                <span class="att" itemprop="hi">subtype</span>(subtipo) se puede utilizar para proporcionar cualquier subclasificación para el elemento, adicional a ésa proporcionada por su 
+                                <span class="att" itemprop="hi">type</span>(tipo) de atributo.</p>
                               </td>
                             </tr>
                           </table>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr itemprop="row">
-                      <td class="odd_label">subtype</td>
-                      <td class="odd_value">(
-                      <span xml:lang="en" lang="en" itemprop="seg">subtype</span>) 
-                      <span xml:lang="es" lang="es" itemprop="seg">proporciona, si es necesario, una subcategorización del elemento.</span>
-                      <div class="table">
-                        <table class="attDef" itemprop="table">
-                          <tr itemprop="row">
-                            <td class="odd_label">
-                              <span xml:lang="es" lang="es" class="label" itemprop="hi">Estado</span>
-                            </td>
-                            <td class="odd_value">
-                              <span xml:lang="es" lang="es" itemprop="seg">Opcional</span>
-                            </td>
-                          </tr>
-                          <tr itemprop="row">
-                            <td class="odd_label">
-                              <span xml:lang="es" lang="es" class="label" itemprop="hi">Tipo de datos</span>
-                            </td>
-                            <td class="odd_value">teidata.enumerated</td>
-                          </tr>
-                          <tr itemprop="row">
-                            <td class="wovenodd-col1">
-                              <span xml:lang="es" lang="es" class="label" itemprop="hi">Nota</span>
-                            </td>
-                            <td class="wovenodd-col2">
-                              <p>El atributo 
-                              <span class="att" itemprop="hi">subtype</span>(subtipo) se puede utilizar para proporcionar cualquier subclasificación para el elemento, adicional a ésa proporcionada por su 
-                              <span class="att" itemprop="hi">type</span>(tipo) de atributo.</p>
-                            </td>
-                          </tr>
-                        </table>
-                      </div></td>
-                    </tr>
-                  </table>
-                </div></td>
+                        </div></td>
+                      </tr>
+                    </table>
+                  </div>
+                </td>
               </tr>
               <tr itemprop="row">
                 <td class="wovenodd-col1">
@@ -344,7 +345,6 @@
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Atributos</span>
                 </td>
                 <td class="wovenodd-col2">
-                <span xml:lang="es" lang="es" itemprop="seg">Atributos </span>
                 <a class="link_ref" itemprop="ref" href="#TEI.att.global" title="att.global proporciona un conjunto de atributos común a todos los elementos del esquema de codificación TEI. [1.3.1.1. Global A...">att.global</a>(
                 <span class="attribute" itemprop="hi">@xml:id</span>, 
                 <span class="attribute" itemprop="hi">@n</span>, 
@@ -541,7 +541,7 @@
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Ejemplo</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <div id="index.xml-egXML-d33e1032" class="pre egXML_valid">
+                  <div id="index.xml-egXML-d33e1029" class="pre egXML_valid">
                   <span class="element">&lt;body&gt;</span> 
                   <span class="element">&lt;div 
                   <span class="attribute">typ</span>="
@@ -605,7 +605,7 @@
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Content model</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <pre id="index.xml-eg-d33e1065" class="pre_eg cdata">
+                  <pre id="index.xml-eg-d33e1062" class="pre_eg cdata">
 &lt;content&gt;
  &lt;sequence minOccurs="1" maxOccurs="1"&gt;
   &lt;alternate minOccurs="0"
@@ -653,7 +653,7 @@
  &lt;/sequence&gt;
 &lt;/content&gt;
     
-<a href="#index.xml-eg-d33e1065" class="anchorlink">⚓</a>
+<a href="#index.xml-eg-d33e1062" class="anchorlink">⚓</a>
 </pre>
                 </td>
               </tr>
@@ -662,7 +662,7 @@
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Declaración</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <pre id="index.xml-eg-d33e1072" class="pre_eg">
+                  <pre id="index.xml-eg-d33e1069" class="pre_eg">
 element div
 {
    
@@ -702,7 +702,7 @@ element div
       )?
    )
 }
-<a href="#index.xml-eg-d33e1072" class="anchorlink">⚓</a>
+<a href="#index.xml-eg-d33e1069" class="anchorlink">⚓</a>
 </pre>
                 </td>
               </tr>
@@ -735,7 +735,6 @@ element div
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Atributos</span>
                 </td>
                 <td class="wovenodd-col2">
-                <span xml:lang="es" lang="es" itemprop="seg">Atributos </span>
                 <a class="link_ref" itemprop="ref" href="#TEI.att.global" title="att.global proporciona un conjunto de atributos común a todos los elementos del esquema de codificación TEI. [1.3.1.1. Global A...">att.global</a>(
                 <span class="attribute" itemprop="hi">@xml:id</span>, 
                 <span class="attribute" itemprop="hi">@n</span>, 
@@ -977,7 +976,7 @@ element div
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Ejemplo</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <div id="index.xml-egXML-d33e1848" class="pre egXML_valid">
+                  <div id="index.xml-egXML-d33e1843" class="pre egXML_valid">
                   <span class="element">&lt;para&gt;</span>Hallgerd was outside. 
                   <span class="element">&lt;q&gt;</span>There is blood on your axe,
                   <span class="element">&lt;/q&gt;</span>she said. 
@@ -1021,12 +1020,12 @@ element div
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Content model</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <pre id="index.xml-eg-d33e1883" class="pre_eg cdata">
+                  <pre id="index.xml-eg-d33e1878" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.paraContent"/&gt;
 &lt;/content&gt;
     
-<a href="#index.xml-eg-d33e1883" class="anchorlink">⚓</a>
+<a href="#index.xml-eg-d33e1878" class="anchorlink">⚓</a>
 </pre>
                 </td>
               </tr>
@@ -1035,7 +1034,7 @@ element div
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Declaración</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <pre id="index.xml-eg-d33e1890" class="pre_eg">
+                  <pre id="index.xml-eg-d33e1885" class="pre_eg">
 element para
 {
    
@@ -1049,7 +1048,7 @@ element para
    
 <a class="link_ref" itemprop="ref" href="#TEI.macro.paraContent" title="macro.paraContent (contenido del párrafo) define el contenido de párrafos y elementos similares. [1.3. The TEI Class System]">macro.paraContent</a>
 }
-<a href="#index.xml-eg-d33e1890" class="anchorlink">⚓</a>
+<a href="#index.xml-eg-d33e1885" class="anchorlink">⚓</a>
 </pre>
                 </td>
               </tr>
@@ -1081,7 +1080,6 @@ element para
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Atributos</span>
                 </td>
                 <td class="wovenodd-col2">
-                <span xml:lang="es" lang="es" itemprop="seg">Atributos </span>
                 <a class="link_ref" itemprop="ref" href="#TEI.att.global" title="att.global proporciona un conjunto de atributos común a todos los elementos del esquema de codificación TEI. [1.3.1.1. Global A...">att.global</a>(
                 <span class="attribute" itemprop="hi">@xml:id</span>, 
                 <span class="attribute" itemprop="hi">@n</span>, 
@@ -1483,7 +1481,7 @@ element para
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Ejemplo</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <div id="index.xml-egXML-d33e2982" class="pre egXML_valid">It is spelled 
+                  <div id="index.xml-egXML-d33e2975" class="pre egXML_valid">It is spelled 
                   <span class="element">&lt;q&gt;</span>Tübingen
                   <span class="element">&lt;/q&gt;</span>— to enter the letter 
                   <span class="element">&lt;q&gt;</span>u
@@ -1499,12 +1497,12 @@ element para
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Content model</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <pre id="index.xml-eg-d33e2996" class="pre_eg cdata">
+                  <pre id="index.xml-eg-d33e2989" class="pre_eg cdata">
 &lt;content&gt;
  &lt;macroRef key="macro.specialPara"/&gt;
 &lt;/content&gt;
     
-<a href="#index.xml-eg-d33e2996" class="anchorlink">⚓</a>
+<a href="#index.xml-eg-d33e2989" class="anchorlink">⚓</a>
 </pre>
                 </td>
               </tr>
@@ -1513,7 +1511,7 @@ element para
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Declaración</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <pre id="index.xml-eg-d33e3003" class="pre_eg">
+                  <pre id="index.xml-eg-d33e2996" class="pre_eg">
 element q
 {
    
@@ -1535,7 +1533,7 @@ element q
    
 <a class="link_ref" itemprop="ref" href="#TEI.macro.specialPara" title="macro.specialPara (contenido de párrafo especial) define el modelo de contenido de elementos tipo notas o entradas de lista que...">macro.specialPara</a>
 }
-<a href="#index.xml-eg-d33e3003" class="anchorlink">⚓</a>
+<a href="#index.xml-eg-d33e2996" class="anchorlink">⚓</a>
 </pre>
                 </td>
               </tr>
@@ -1651,12 +1649,12 @@ element q
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Content model</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <pre id="index.xml-eg-d33e3197" class="pre_eg cdata">
+                  <pre id="index.xml-eg-d33e3190" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef key="teidata.word"/&gt;
 &lt;/content&gt;
     
-<a href="#index.xml-eg-d33e3197" class="anchorlink">⚓</a>
+<a href="#index.xml-eg-d33e3190" class="anchorlink">⚓</a>
 </pre>
                 </td>
               </tr>
@@ -1665,10 +1663,10 @@ element q
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Declaración</span>
                 </td>
                 <td class="wovenodd-col2">
-                  <pre id="index.xml-eg-d33e3204" class="pre_eg">
+                  <pre id="index.xml-eg-d33e3197" class="pre_eg">
 teidata.enumerated = 
 <a class="link_ref" itemprop="ref" href="#TEI.teidata.word" title="teidata.word define una gama de valores de atributos expresados como una única palabra o señal.">teidata.word</a>
-<a href="#index.xml-eg-d33e3204" class="anchorlink">⚓</a>
+<a href="#index.xml-eg-d33e3197" class="anchorlink">⚓</a>
 </pre>
                 </td>
               </tr>

--- a/common/common_tagdocs.xsl
+++ b/common/common_tagdocs.xsl
@@ -2669,31 +2669,33 @@
       </xsl:when>
       <xsl:when test="not($clatts = '')">
         <xsl:if test="ancestor::tei:schemaSpec and key('CLASSES', 'att.global')">
-          <xsl:element namespace="{$outputNS}" name="{$segName}">
-            <xsl:attribute name="{$langAttributeName}">
-              <xsl:value-of select="$documentationLanguage"/>
-            </xsl:attribute>
-            <xsl:variable name="word">
-              <xsl:choose>
-                <xsl:when test="not($autoGlobal = 'true')">Attributes</xsl:when>
-                <xsl:when test=".//tei:attDef">In addition to global attributes
-                  and those inherited from</xsl:when>
-                <xsl:otherwise>Global attributes and those inherited
-                  from</xsl:otherwise>
-              </xsl:choose>
-            </xsl:variable>
-            <xsl:sequence select="tei:i18n($word)"/>
-            <xsl:value-of select="$spaceCharacter"/>
-          </xsl:element>
+          <xsl:variable name="word">
+            <xsl:choose>
+              <!-- Per issue 515, the word "Attributes" need not be output here. -->
+              <xsl:when test="not($autoGlobal = 'true')"><!--Attributes--></xsl:when>
+              <xsl:when test=".//tei:attDef">In addition to global attributes
+                and those inherited from</xsl:when>
+              <xsl:otherwise>Global attributes and those inherited
+                from</xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+          <xsl:if test="normalize-space($word) ne ''">
+            <xsl:element namespace="{$outputNS}" name="{$segName}">
+              <xsl:attribute name="{$langAttributeName}">
+                <xsl:value-of select="$documentationLanguage"/>
+              </xsl:attribute>
+              <xsl:sequence select="tei:i18n($word) || $spaceCharacter"/>
+            </xsl:element>
+          </xsl:if>
         </xsl:if>
         <xsl:copy-of select="$clatts"/>
       </xsl:when>
-      <xsl:when
-        test="ancestor::tei:schemaSpec and not(key('CLASSES', 'att.global'))"> </xsl:when>
+      <xsl:when test="ancestor::tei:schemaSpec and not(key('CLASSES', 'att.global'))"> </xsl:when>
       <xsl:otherwise>
         <xsl:variable name="word">
           <xsl:choose>
-            <xsl:when test="not($autoGlobal = 'true')">Attributes</xsl:when>
+            <!-- Per issue 515, the word "Attributes" need not be output here. -->
+            <xsl:when test="not($autoGlobal = 'true')"><!--Attributes--></xsl:when>
             <xsl:when test=".//tei:attDef">In addition to global
               attributes</xsl:when>
             <xsl:otherwise>Global attributes only</xsl:otherwise>


### PR DESCRIPTION
Working with @helenasabel, @sydb, @martinascholger and @nccole on issue #515: rewrote attribute listings output to suppress unwanted word.