### PR TITLE
Allow the `<ref>` elements to get processed:

### DIFF
--- a/latex/latex_tagdocs.xsl
+++ b/latex/latex_tagdocs.xsl
@@ -287,22 +287,12 @@ of this software, even if advised of the possibility of such damage.
 \end{sansreflist}
 </xsl:template>
 
+<!-- Insert pointy brackets around element names in specLists (see
+     https://github.com/TEIC/Stylesheets/issues/537.) -->
    <xsl:template match="tei:hi[tei:match(@rend,'specList-elementSpec')]">
-      <xsl:text>[\textbf{&lt;</xsl:text>
-      <xsl:value-of select="."/>
-      <xsl:text>&gt;}]</xsl:text>
-   </xsl:template>
-
-   <xsl:template match="tei:hi[tei:match(@rend,'specList-macroSpec')]">
-      <xsl:text>[\textbf{</xsl:text>
-      <xsl:value-of select="."/>
-      <xsl:text>}]</xsl:text>
-   </xsl:template>
-
-   <xsl:template match="tei:hi[tei:match(@rend,'specList-classSpec')]">
-      <xsl:text>[\textbf{</xsl:text>
-      <xsl:value-of select="."/>
-      <xsl:text>}]</xsl:text>
+      <xsl:text>&lt;</xsl:text>
+      <xsl:apply-templates/>
+      <xsl:text>&gt;</xsl:text>
    </xsl:template>
 
    <xsl:template match="tei:hi[tei:match(@rend,'label')  or tei:match(@rend,'defaultVal')]">

--- a/latex/latex_tagdocs.xsl
+++ b/latex/latex_tagdocs.xsl
@@ -287,12 +287,22 @@ of this software, even if advised of the possibility of such damage.
 \end{sansreflist}
 </xsl:template>
 
-<!-- Insert pointy brackets around element names in specLists (see
-     https://github.com/TEIC/Stylesheets/issues/537.) -->
    <xsl:template match="tei:hi[tei:match(@rend,'specList-elementSpec')]">
-      <xsl:text>&lt;</xsl:text>
-      <xsl:apply-templates/>
-      <xsl:text>&gt;</xsl:text>
+      <xsl:text>[\textbf{&lt;</xsl:text>
+      <xsl:value-of select="."/>
+      <xsl:text>&gt;}]</xsl:text>
+   </xsl:template>
+
+   <xsl:template match="tei:hi[tei:match(@rend,'specList-macroSpec')]">
+      <xsl:text>[\textbf{</xsl:text>
+      <xsl:value-of select="."/>
+      <xsl:text>}]</xsl:text>
+   </xsl:template>
+
+   <xsl:template match="tei:hi[tei:match(@rend,'specList-classSpec')]">
+      <xsl:text>[\textbf{</xsl:text>
+      <xsl:value-of select="."/>
+      <xsl:text>}]</xsl:text>
    </xsl:template>
 
    <xsl:template match="tei:hi[tei:match(@rend,'label')  or tei:match(@rend,'defaultVal')]">

--- a/latex/latex_tagdocs.xsl
+++ b/latex/latex_tagdocs.xsl
@@ -287,22 +287,33 @@ of this software, even if advised of the possibility of such damage.
 \end{sansreflist}
 </xsl:template>
 
+   <!-- 
+      dedicated processing of links in specLists
+      which become the custom label of a LaTeX list item
+      (https://github.com/TEIC/Stylesheets/issues/537).
+   -->
    <xsl:template match="tei:hi[tei:match(@rend,'specList-elementSpec')]">
-      <xsl:text>[\textbf{&lt;</xsl:text>
-      <xsl:value-of select="."/>
-      <xsl:text>&gt;}]</xsl:text>
+      <xsl:text>[{\hyperref[</xsl:text>
+      <xsl:value-of select="substring(tei:ref/@target, 2)"/>
+      <xsl:text>]{&lt;</xsl:text>
+      <xsl:value-of select="tei:ref"/>
+      <xsl:text>&gt;}}]</xsl:text>
    </xsl:template>
 
    <xsl:template match="tei:hi[tei:match(@rend,'specList-macroSpec')]">
-      <xsl:text>[\textbf{</xsl:text>
-      <xsl:value-of select="."/>
-      <xsl:text>}]</xsl:text>
+      <xsl:text>[{\hyperref[</xsl:text>
+      <xsl:value-of select="substring(tei:ref/@target, 2)"/>
+      <xsl:text>]{</xsl:text>
+      <xsl:value-of select="tei:ref"/>
+      <xsl:text>}}]</xsl:text>
    </xsl:template>
 
    <xsl:template match="tei:hi[tei:match(@rend,'specList-classSpec')]">
-      <xsl:text>[\textbf{</xsl:text>
-      <xsl:value-of select="."/>
-      <xsl:text>}]</xsl:text>
+      <xsl:text>[{\hyperref[</xsl:text>
+      <xsl:value-of select="substring(tei:ref/@target, 2)"/>
+      <xsl:text>]{</xsl:text>
+      <xsl:value-of select="tei:ref"/>
+      <xsl:text>}}]</xsl:text>
    </xsl:template>
 
    <xsl:template match="tei:hi[tei:match(@rend,'label')  or tei:match(@rend,'defaultVal')]">


### PR DESCRIPTION
Stylesheets group, with big thanks to @hcayless, realized
a) these things (contents of `<hi>` in intermediate Lite stage that contain the `<ref>`s that were not working) were being processed with `<value-of>`, not `<apply-templates>`; and
b) furthermore, the templates for `<ref>` would have been processed if these templates for `<hi>` did not exist, and since all they were doing in 2 of 3 cases was adding boldface we did not like (and failing to process the `<ref>`s), we just nuked 2 of them and fixed the 3rd (which also adds the pointy brackets for element names).

We tested this once, in a Docker container, and it seemed to work. If one of either @peterstadler, @martindholmes, or @npcole can reproduce that this works (by generating PDF and looking at the list of macro names in section 1.4.1 “Standard Content Models” on page 16 of the PDF, and ensuring they _are_ working links, and also looking around elsewhere in the PDF _Guidelines_ and making sure we didn’t break anything else), then I think one of the other two can just merge it.