### PR TITLE
Flag out-of-date Translations

### DIFF
--- a/Test/expected-results/test15.odd.html
+++ b/Test/expected-results/test15.odd.html
@@ -91,7 +91,7 @@
           <div class="table">
             <table class="wovenodd" itemprop="table">
               <tr itemprop="row">
-                <td colspan="2" class="wovenodd-col2">
+                <td colspan="2" class="wovenodd-col2 outOfDateTranslation">
                 <span class="label" itemprop="hi">att.typed</span> 
                 <span xml:lang="es" lang="es" class="outOfDateTranslation" itemprop="seg">proporciona atributos genéricos utilizables para cualquier clasificación o subclasificación de elementos.</span>[
                 <a class="link_ref" itemprop="ref" href="https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ST.html#STECAT">1.3.1. Attribute Classes</a>
@@ -296,7 +296,7 @@
                               <td class="wovenodd-col1">
                                 <span xml:lang="es" lang="es" class="label" itemprop="hi">Nota</span>
                               </td>
-                              <td class="wovenodd-col2">
+                              <td class="wovenodd-col2 outOfDateTranslation">
                                 <p>El atributo 
                                 <span class="att" itemprop="hi">subtype</span>(subtipo) se puede utilizar para proporcionar cualquier subclasificación para el elemento, adicional a ésa proporcionada por su 
                                 <span class="att" itemprop="hi">type</span>(tipo) de atributo.</p>
@@ -1067,7 +1067,7 @@ element para
           <div class="table">
             <table class="wovenodd" itemprop="table">
               <tr itemprop="row">
-                <td colspan="2" class="wovenodd-col2">
+                <td colspan="2" class="wovenodd-col2 outOfDateTranslation">
                 <span class="label" itemprop="hi">&lt;q&gt;</span>(
                 <span xml:lang="es" lang="es" class="outOfDateTranslation" itemprop="seg">discurso citado, pensado o escrito</span>) 
                 <span xml:lang="es" lang="es" class="outOfDateTranslation" itemprop="seg">contiene material que se marca como (ostensiblemente) citado de cualquier otro sitio: en la narrativa, este elemento se usa para marcar discursos en estilo directo o indirecto; en diccionarios puede usarse para marcar ejemplos reales o ideados de uso; en descripciones de manuscritos u otros metadatos, para marcar extractos citados de la fuente que se documenta.</span>[
@@ -1116,7 +1116,7 @@ element para
                   <table class="attList" itemprop="table">
                     <tr itemprop="row">
                       <td class="odd_label">typ</td>
-                      <td class="odd_value">(
+                      <td class="odd_value outOfDateTranslation">(
                       <span xml:lang="en" lang="en" itemprop="seg">type</span>) 
                       <span xml:lang="es" lang="es" class="outOfDateTranslation" itemprop="seg">Puede usarse para indicar si el material citado es hablado o pensado, o para caracterizarlo con más precisión.</span>
                       <div class="table">
@@ -1473,7 +1473,7 @@ element para
                 <td class="wovenodd-col1">
                   <span xml:lang="es" lang="es" class="label" itemprop="hi">Nota</span>
                 </td>
-                <td class="wovenodd-col2">
+                <td class="wovenodd-col2 outOfDateTranslation">
                   <p>Puede ser utilizado para indicar que un pasaje es distinguido del texto circundante mediante las comillas por las razones que sean sobre las cuales no se hace ninguna declaración. Cuando se utiliza de este modo, 
                   <a class="link_ref" itemprop="ref" href="#TEI.q" title="&lt;q&gt;">&lt;q&gt;</a>puede ser considerado como una marca sintáctica para 
                   <a class="link_ref" itemprop="ref" href="#TEI.hi" title="hi (subrayado) marca una palabra o frase gráficamente diferente del resto del texto que la circunda por causas sobre las que no...">&lt;hi&gt;</a>con un valor de 
@@ -1552,7 +1552,7 @@ element q
           <div class="table">
             <table class="wovenodd" itemprop="table">
               <tr itemprop="row">
-                <td colspan="2">
+                <td colspan="2" class="outOfDateTranslation">
                 <span class="label" itemprop="hi">enum</span> 
                 <span xml:lang="es" lang="es" class="outOfDateTranslation" itemprop="seg">define la gama de valores de atributos expresados como una única palabra o señal tomada de una lista de posibilidades documentadas.</span></td>
               </tr>

--- a/common/common_tagdocs.xsl
+++ b/common/common_tagdocs.xsl
@@ -155,6 +155,9 @@
       <xsl:element namespace="{$outputNS}" name="{$cellName}">
         <xsl:attribute name="{$rendName}">
           <xsl:text>odd_value</xsl:text>
+          <xsl:if test="tei:descOrGlossOutOfDate(.)">
+            <xsl:text> outOfDateTranslation</xsl:text>
+          </xsl:if>
         </xsl:attribute>
         <xsl:sequence select="tei:makeDescription(., true(), true())"/>
         <xsl:apply-templates select="tei:valList"/>
@@ -210,6 +213,9 @@
       <xsl:element namespace="{$outputNS}" name="{$cellName}">
         <xsl:attribute name="{$rendName}">
           <xsl:text>odd_value</xsl:text>
+          <xsl:if test="tei:descOrGlossOutOfDate(.)">
+            <xsl:text> outOfDateTranslation</xsl:text>
+          </xsl:if>
         </xsl:attribute>
         <xsl:sequence select="tei:makeDescription(., false(), true())"/>
         <xsl:apply-templates select="tei:valList"/>
@@ -238,6 +244,9 @@
       <xsl:element namespace="{$outputNS}" name="{$cellName}">
         <xsl:attribute name="{$rendName}">
           <xsl:text>odd_value</xsl:text>
+          <xsl:if test="tei:descOrGlossOutOfDate(.)">
+            <xsl:text> outOfDateTranslation</xsl:text>
+          </xsl:if>
         </xsl:attribute>
         <!-- MDH 2018-01-21: setting third param ($makeMiniList) to 
           false so we can stop building ugly and superfluous lists 
@@ -473,6 +482,9 @@
             <xsl:attribute name="{$colspan}">2</xsl:attribute>
             <xsl:attribute name="{$rendName}">
               <xsl:text>wovenodd-col2</xsl:text>
+              <xsl:if test="tei:descOrGlossOutOfDate(.)">
+                <xsl:text> outOfDateTranslation</xsl:text>
+              </xsl:if>
             </xsl:attribute>
             <xsl:element namespace="{$outputNS}" name="{$hiName}">
               <xsl:attribute name="{$rendName}">
@@ -664,6 +676,9 @@
             <xsl:attribute name="{$colspan}">2</xsl:attribute>
             <xsl:attribute name="{$rendName}">
               <xsl:text>wovenodd-col2</xsl:text>
+              <xsl:if test="tei:descOrGlossOutOfDate(.)">
+                <xsl:text> outOfDateTranslation</xsl:text>
+              </xsl:if>
             </xsl:attribute>
             <xsl:element namespace="{$outputNS}" name="{$hiName}">
               <xsl:attribute name="{$rendName}">
@@ -996,6 +1011,9 @@
       <xsl:element namespace="{$outputNS}" name="{$cellName}">
         <xsl:attribute name="{$rendName}">
           <xsl:text>wovenodd-col2</xsl:text>
+          <xsl:if test="tei:descOrGlossOutOfDate(.)">
+            <xsl:text> outOfDateTranslation</xsl:text>
+          </xsl:if>
         </xsl:attribute>
         <xsl:sequence select="tei:makeDescription(., true(), true())"/>
         <xsl:for-each select="tei:constraint">
@@ -1352,6 +1370,11 @@
         <xsl:element namespace="{$outputNS}" name="{$rowName}">
           <xsl:element namespace="{$outputNS}" name="{$cellName}">
             <xsl:attribute name="{$colspan}">2</xsl:attribute>
+            <xsl:if test="tei:descOrGlossOutOfDate(.)">
+              <xsl:attribute name="{$rendName}">
+                <xsl:text>outOfDateTranslation</xsl:text>
+              </xsl:attribute>
+            </xsl:if>
             <xsl:element namespace="{$outputNS}" name="{$hiName}">
               <xsl:attribute name="{$rendName}">
                 <xsl:text>label</xsl:text>
@@ -1382,6 +1405,9 @@
           <xsl:element namespace="{$outputNS}" name="{$cellName}">
             <xsl:attribute name="{$rendName}">
               <xsl:text>wovenodd-col2</xsl:text>
+              <xsl:if test="tei:descOrGlossOutOfDate(.)">
+                <xsl:text> outOfDateTranslation</xsl:text>
+              </xsl:if>
             </xsl:attribute>
             <xsl:call-template name="generateModelParents">
               <xsl:with-param name="showElements">true</xsl:with-param>
@@ -1418,6 +1444,11 @@
         <xsl:element namespace="{$outputNS}" name="{$rowName}">
           <xsl:element namespace="{$outputNS}" name="{$cellName}">
             <xsl:attribute name="{$colspan}">2</xsl:attribute>
+            <xsl:if test="tei:descOrGlossOutOfDate(.)">
+              <xsl:attribute name="{$rendName}">
+                <xsl:text>outOfDateTranslation</xsl:text>
+              </xsl:attribute>
+            </xsl:if>
             <xsl:element namespace="{$outputNS}" name="{$hiName}">
               <xsl:attribute name="{$rendName}">
                 <xsl:text>label</xsl:text>
@@ -1585,6 +1616,9 @@
       <xsl:element namespace="{$outputNS}" name="{$labelName}">
         <xsl:attribute name="{$rendName}">
           <xsl:text>moduleSpecHead</xsl:text>
+          <xsl:if test="tei:descOrGlossOutOfDate(.)">
+            <xsl:text> outOfDateTranslation</xsl:text>
+          </xsl:if>
         </xsl:attribute>
         <xsl:element namespace="{$outputNS}" name="{$segName}">
           <xsl:attribute name="{$langAttributeName}">
@@ -1723,6 +1757,9 @@
         <xsl:element namespace="{$outputNS}" name="{$cellName}">
           <xsl:attribute name="{$rendName}">
             <xsl:text>wovenodd-col2</xsl:text>
+            <xsl:if test="preceding-sibling::tei:remarks[@xml:lang='en']/@versionDate gt @versionDate">
+              <xsl:text> outOfDateTranslation</xsl:text>
+            </xsl:if>
           </xsl:attribute>
           <xsl:comment>&#160;</xsl:comment>
           <xsl:apply-templates/>
@@ -1925,6 +1962,9 @@
         <xsl:element namespace="{$outputNS}" name="{$ddName}">
           <xsl:attribute name="{$rendName}">
             <xsl:text>odd_value</xsl:text>
+            <xsl:if test="tei:descOrGlossOutOfDate(.)">
+              <xsl:text> outOfDateTranslation</xsl:text>
+            </xsl:if>
           </xsl:attribute>
           <xsl:if test="tei:paramList">
             <xsl:text>(</xsl:text>

--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -1229,6 +1229,18 @@ of this software, even if advised of the possibility of such damage.
   </xsl:variable>
   <xsl:copy-of select="$D"/>
   </xsl:function>
+  
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>whether there is an out-of-date desc or gloss in the translation language</desc>
+  </doc>
+  <xsl:function name="tei:descOrGlossOutOfDate">
+    <xsl:param name="context"/>
+    <xsl:for-each select="$context">
+      <xsl:variable name="lang" select="tei:generateDocumentationLang(.)[1]"/>
+      <xsl:sequence select="tei:desc[@xml:lang='en']/@versionDate gt tei:desc[@xml:lang=$lang]/@versionDate
+                         or tei:gloss[@xml:lang='en']/@versionDate gt tei:gloss[@xml:lang=$lang]/@versionDate"></xsl:sequence>
+    </xsl:for-each>
+  </xsl:function>
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
     <desc>[localisation]work out the language for documentation</desc>

--- a/i18n.xml
+++ b/i18n.xml
@@ -2264,4 +2264,12 @@
      <text xml:lang="de" lang3="deu">Namensraum</text>
      <text xml:lang="sl" lang3="slv">Imenski prostor</text>
   </entry>
+  <entry>
+    <key>translationOutOfDate</key>
+    <text xml:lang="en">Translation out of date.</text>
+    <text xml:lang="es">Esta traducción necesita ser actualizada.</text>
+    <text xml:lang="de">Diese Übersetzung muss aktualisiert werden.</text>
+    <text xml:lang="fr">Cette traduction doit être mise à jour.</text>
+    <text xml:lang="it">Questa traduzione deve essere aggiornata.</text>
+  </entry>
 </i18n>


### PR DESCRIPTION
This adds a class, 'outOfDateTranslation', to elements containing glosses, descs, or remarks. This will enable CSS and/or JavaScript to show when a translation is out of date. This would implement #138.