### PR TITLE
add mode "xref" to text-template

### DIFF
--- a/common/functions.xsl
+++ b/common/functions.xsl
@@ -494,7 +494,7 @@ of this software, even if advised of the possibility of such damage.
       trim trailing space on the last text node in an element,
       trim both if a text node is both first and last, i.e., is the only text node in the element.</desc>
   </doc>
-  <xsl:template match="text()" mode="#default plain">
+  <xsl:template match="text()" mode="#default plain xref">
     <xsl:choose>
       <xsl:when test="ancestor::*[@xml:space][1]/@xml:space='preserve'">
         <xsl:value-of select="tei:escapeChars(.,parent::*)"/>


### PR DESCRIPTION
this fixes #565 by applying the text template and its `tei:escapeChars` function to the computed link text of pointers which are processed in the "xref" mode. (Revealed by the Oxygen XSLT debugger)

