### PR TITLE
Fix #607, I hope: remove erroneous bits of text from version URL 

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -751,11 +751,11 @@ test-namespaces: actual
 
 	$(BINDIR)/teitornc $(FLAGS) test35.odd $(AR)/test35.rnc
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/test35.rnc
-	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/test35.rnc
+	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/test35.rnc
 	if [ $(DIFFNOW) -eq 1 ]; \
 	   then diff -bBw $(AR)/test35.rnc $(ER)/test35.rnc; \
 	   else echo "==deferring: \` diff -bBw $(AR)/test35.rnc $(ER)/test35.rnc \`"; fi
-	
+
 #HBS 2022-04-30 tests attributes @include and @except
 	$(BINDIR)/teitornc $(FLAGS) testClass.odd $(AR)/testClass.rnc
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/testClass.rnc

--- a/Test/expected-results/test-pure.rnc
+++ b/Test/expected-results/test-pure.rnc
@@ -6,8 +6,6 @@ namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
 
-#
-
 sch:ns [ prefix = "tei" uri = "http://www.tei-c.org/ns/1.0" ]
 stuff =
   

--- a/Test/expected-results/test-pure2.rnc
+++ b/Test/expected-results/test-pure2.rnc
@@ -5,8 +5,6 @@ namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
 
-#
-
 sch:ns [ prefix = "tei" uri = "http://www.tei-c.org/ns/1.0" ]
 stuffPart = bob | bit
 stuff =

--- a/Test/expected-results/test15.odd.rnc
+++ b/Test/expected-results/test15.odd.rnc
@@ -7,8 +7,6 @@ namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
-
-#
 macro.abContent = (text | model.paraPart | ab)*
 macro.paraContent = (text | model.paraPart)*
 macro.limitedContent = (text | model.limitedPhrase | model.inter)*

--- a/Test/expected-results/test21.odd.rnc
+++ b/Test/expected-results/test21.odd.rnc
@@ -7,8 +7,6 @@ namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
-
-#
 macro.abContent = (text | model.paraPart | ab)*
 macro.paraContent = (text | model.paraPart)*
 macro.limitedContent = (text | model.limitedPhrase | model.inter)*
@@ -8093,9 +8091,9 @@ facsimile =
            sch:report [
              test = "child::text()[ normalize-space(.) ne '']"
              "\x{a}" ~
-             "  	  A facsimile element represents a text with images, thus\x{a}" ~
-             "	  transcribed text should not be present within it.\x{a}" ~
-             "	"
+             "          A facsimile element represents a text with images, thus\x{a}" ~
+             "          transcribed text should not be present within it.\x{a}" ~
+             "        "
            ]
            "\x{a}" ~
            "            "

--- a/Test/expected-results/test30.rnc
+++ b/Test/expected-results/test30.rnc
@@ -8,8 +8,6 @@ namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
-
-#
 Tmacro.abContent = (text | Tmodel.paraPart | Tab)*
 Tmacro.paraContent = (text | Tmodel.paraPart)*
 Tmacro.limitedContent = (text | Tmodel.limitedPhrase | Tmodel.inter)*
@@ -6488,9 +6486,9 @@ Tfacsimile =
            sch:report [
              test = "child::text()[ normalize-space(.) ne '']"
              "\x{a}" ~
-             "  	  A facsimile element represents a text with images, thus\x{a}" ~
-             "	  transcribed text should not be present within it.\x{a}" ~
-             "	"
+             "          A facsimile element represents a text with images, thus\x{a}" ~
+             "          transcribed text should not be present within it.\x{a}" ~
+             "        "
            ]
            "\x{a}" ~
            "            "

--- a/Test/expected-results/test33.rnc
+++ b/Test/expected-results/test33.rnc
@@ -9,8 +9,6 @@ namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
-
-#
 tei_macro.abContent = (text | tei_model.paraPart | tei_ab)*
 tei_macro.paraContent = (text | tei_model.paraPart)*
 tei_macro.limitedContent =

--- a/Test/expected-results/test34.rnc
+++ b/Test/expected-results/test34.rnc
@@ -10,8 +10,6 @@ namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
-
-#
 tei_macro.abContent = (text | tei_model.paraPart | tei_ab)*
 tei_macro.paraContent = (text | tei_model.paraPart)*
 tei_macro.limitedContent =

--- a/Test/expected-results/testClass.rnc
+++ b/Test/expected-results/testClass.rnc
@@ -8,8 +8,6 @@ namespace xi = "http://www.w3.org/2001/XInclude"
 namespace xlink = "http://www.w3.org/1999/xlink"
 
 
-#
-
 sch:ns [ prefix = "tei" uri = "http://www.tei-c.org/ns/1.0" ]
 macro.paraContent = (text | model.paraPart)*
 att.written.attributes = att.written.attribute.hand

--- a/debian-tei-xsl/debian/changelog
+++ b/debian-tei-xsl/debian/changelog
@@ -1,3 +1,9 @@
+tei-xsl (7.56.0a) natty; urgency=low
+
+  * new release from upstream
+
+ -- TEI                         <editors@www.tei-c.org>  Mon, 01 May 2023 12:16:18 -0400
+
 tei-xsl (7.55.0a) natty; urgency=low
 
   * new release from upstream

--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -1869,13 +1869,13 @@ select="$makeDecls"/></xsl:message>
         <!-- SB modified 2023-05-01 —
           * Simplify code
           * Correctly extract only the version number itself per ticket #607
-            - But note that it is quite fragile, in that it is searching for a very particular string
+            - Note that we need to be prepared for both "P5 Version&#xA0;…" and just "Version&#xA0;…"
           * Normalize space of “TEI Edition” output so it is all on one line
         -->
         <xsl:variable name="TEIVersion" select="ancestor-or-self::tei:TEI/processing-instruction()[name() eq 'TEIVERSION'][1]"/>
         <xsl:variable name="TEIVersion-edition" select="substring-before( $TEIVersion, ' Last')"/>
         <xsl:variable name="TEIVersion-datestring" select="concat(' Last', substring-after( $TEIVersion, ' Last') )"/>
-        <xsl:variable name="TEIVersion-only" select="replace( $TEIVersion-edition, '^P5 Version&#xA0;(\d+\.\d+\.\d+[abABɑΑΒβ]?)\.$', '$1')"/>
+        <xsl:variable name="TEIVersion-only" select="replace( $TEIVersion-edition, '^(P5 )?Version&#xA0;(\d+\.\d+\.\d+[abABɑΑΒβ]?)\.$', '$2')"/>
         <xsl:variable name="versionURL" select="concat( $defaultTEIServer, $TEIVersion-only, '/')"/>
         <xsl:sequence select="'&#x0A;TEI Edition: '||normalize-space($TEIVersion)"/>
         <xsl:sequence select="'&#x0A;TEI Edition Location: '||$versionURL"/>

--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -23,7 +23,7 @@
 Unported License http://creativecommons.org/licenses/by-sa/3.0/ 
 
 2. http://www.opensource.org/licenses/BSD-2-Clause
-		
+                
 
 
 Redistribution and use in source and binary forms, with or without
@@ -153,7 +153,7 @@ of this software, even if advised of the possibility of such damage.
       <xsl:otherwise>
         <xsl:value-of select="$defaultTEIServer"/>
         <xsl:value-of select="$defaultTEIVersion"/>
-	<xsl:text>/xml/tei/odd/p5subset.xml</xsl:text>
+        <xsl:text>/xml/tei/odd/p5subset.xml</xsl:text>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
@@ -194,13 +194,13 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="processing-instruction()" mode="#default tangle">
     <xsl:choose>
       <xsl:when test="name(.) = 'odds'">
-	<xsl:choose>
-  	  <xsl:when test=".='date'"> This formatted version of the Guidelines was created on
-	  <xsl:sequence select="tei:whatsTheDate()"/>. </xsl:when>
-	</xsl:choose>
+        <xsl:choose>
+          <xsl:when test=".='date'"> This formatted version of the Guidelines was created on
+          <xsl:sequence select="tei:whatsTheDate()"/>. </xsl:when>
+        </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
-	<xsl:copy-of select="."/>
+        <xsl:copy-of select="."/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -232,7 +232,7 @@ of this software, even if advised of the possibility of such damage.
       <xsl:otherwise>
         <xsl:text>/&gt;</xsl:text>
         <xsl:if test="node()[last()]/self::rng:*">
-          <xsl:text>&#10;	  </xsl:text>
+          <xsl:text>&#10;         </xsl:text>
         </xsl:if>
       </xsl:otherwise>
     </xsl:choose>
@@ -257,10 +257,10 @@ of this software, even if advised of the possibility of such damage.
         <xsl:apply-templates select="rng:*|tei:*|text()|comment()"/>
       </xsl:when>
       <xsl:otherwise>
-	<zeroOrMore xmlns="http://relaxng.org/ns/structure/1.0" >
+        <zeroOrMore xmlns="http://relaxng.org/ns/structure/1.0" >
           <xsl:copy-of select="@*"/>
           <xsl:apply-templates select="rng:*|tei:*|text()|comment()"/>
-	</zeroOrMore>
+        </zeroOrMore>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -272,10 +272,10 @@ of this software, even if advised of the possibility of such damage.
         <xsl:apply-templates select="a:*|rng:*|tei:*|text()|comment()"/>
       </xsl:when>
       <xsl:otherwise>
-	<choice xmlns="http://relaxng.org/ns/structure/1.0">
+        <choice xmlns="http://relaxng.org/ns/structure/1.0">
           <xsl:copy-of select="@*"/>
           <xsl:apply-templates select="a:*|rng:*|tei:*|text()|comment()"/>
-	</choice>
+        </choice>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -296,11 +296,11 @@ of this software, even if advised of the possibility of such damage.
         </xsl:variable>
         <xsl:choose>
           <xsl:when test="$that=$this"/>
-	  <xsl:otherwise>
-	    <group xmlns="http://relaxng.org/ns/structure/1.0">
+          <xsl:otherwise>
+            <group xmlns="http://relaxng.org/ns/structure/1.0">
               <xsl:copy-of select="@*"/>
               <xsl:apply-templates select="rng:*|tei:*|text()|comment()"/>
-	    </group>
+            </group>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
@@ -308,7 +308,7 @@ of this software, even if advised of the possibility of such damage.
         <xsl:element name="{local-name()}" namespace="http://relaxng.org/ns/structure/1.0" >
           <xsl:copy-of select="@*"/>
           <xsl:apply-templates select="rng:*|tei:*|text()|comment()"/>
-	</xsl:element>
+        </xsl:element>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -345,11 +345,11 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:attRef" mode="tangle">  
     <xsl:choose>
       <xsl:when test="key('IDENTS',@class)">
-	<ref xmlns="http://relaxng.org/ns/structure/1.0" name="{tei:generateAttRef(.,$generalPrefix)}"/>
+        <ref xmlns="http://relaxng.org/ns/structure/1.0" name="{tei:generateAttRef(.,$generalPrefix)}"/>
       </xsl:when>
       <xsl:when test="@class"/>
       <xsl:otherwise>
-	<ref xmlns="http://relaxng.org/ns/structure/1.0" name="{@name}"/>
+        <ref xmlns="http://relaxng.org/ns/structure/1.0" name="{@name}"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -432,7 +432,7 @@ of this software, even if advised of the possibility of such damage.
       <xsl:when test="@type='model'">
         <xsl:apply-templates mode="processModel" select=".">
           <xsl:with-param name="declare">false</xsl:with-param>
-          <!--	    <xsl:choose>
+          <!--      <xsl:choose>
             <xsl:when test="@module='tei'">true</xsl:when>
             <xsl:otherwise>false</xsl:otherwise>
             </xsl:choose>
@@ -525,12 +525,12 @@ of this software, even if advised of the possibility of such damage.
                   <xsl:value-of select="@generate"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:text>&#10;			     NULL
-			     alternation
-			     sequence
-			     sequenceOptional
-			     sequenceOptionalRepeatable
-			   sequenceRepeatable</xsl:text>
+                  <xsl:text>&#10;                            NULL
+                             alternation
+                             sequence
+                             sequenceOptional
+                             sequenceOptionalRepeatable
+                           sequenceRepeatable</xsl:text>
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:with-param>
@@ -593,12 +593,12 @@ of this software, even if advised of the possibility of such damage.
     </xsl:variable>
     <xsl:variable name="localprefix">
       <xsl:choose>
-	<xsl:when test="@prefix">
-	  <xsl:value-of select="@prefix"/>
-	</xsl:when>
-	<xsl:otherwise>
-	  <xsl:value-of select="$generalPrefix"/>
-	</xsl:otherwise>
+        <xsl:when test="@prefix">
+          <xsl:value-of select="@prefix"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$generalPrefix"/>
+        </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
 
@@ -657,7 +657,7 @@ select="$makeDecls"/></xsl:message>
                 <xsl:when test="$type='sequence'">
                   <xsl:for-each select="key('CLASSMEMBERS',$thisClass)">
                     <xsl:apply-templates select="."
-					 mode="classmember">
+                                         mode="classmember">
                       <xsl:with-param name="theClass" select="$thisClass"/>
                       <xsl:with-param name="suffix" select="$type"/>
                     </xsl:apply-templates>
@@ -667,7 +667,7 @@ select="$makeDecls"/></xsl:message>
                   <xsl:for-each select="key('CLASSMEMBERS',$thisClass)">
                     <optional xmlns="http://relaxng.org/ns/structure/1.0">
                       <xsl:apply-templates select="."  mode="classmember">
-			<xsl:with-param name="theClass" select="$thisClass"/>
+                        <xsl:with-param name="theClass" select="$thisClass"/>
                         <xsl:with-param name="suffix" select="$type"/>
                       </xsl:apply-templates>
                     </optional>
@@ -678,7 +678,7 @@ select="$makeDecls"/></xsl:message>
                   <xsl:for-each select="key('CLASSMEMBERS',$thisClass)">
                     <oneOrMore xmlns="http://relaxng.org/ns/structure/1.0">
                       <xsl:apply-templates select="."  mode="classmember">
-			<xsl:with-param name="theClass" select="$thisClass"/>		   
+                        <xsl:with-param name="theClass" select="$thisClass"/>              
                         <xsl:with-param name="suffix" select="$type"/>
                       </xsl:apply-templates>
                     </oneOrMore>
@@ -690,7 +690,7 @@ select="$makeDecls"/></xsl:message>
                     <zeroOrMore xmlns="http://relaxng.org/ns/structure/1.0">
                       <xsl:apply-templates select="." mode="classmember">
                         <xsl:with-param name="suffix" select="$type"/>
-			<xsl:with-param name="theClass" select="$thisClass"/>
+                        <xsl:with-param name="theClass" select="$thisClass"/>
                       </xsl:apply-templates>
                     </zeroOrMore>
                   </xsl:for-each>
@@ -701,7 +701,7 @@ select="$makeDecls"/></xsl:message>
                     <xsl:for-each select="key('CLASSMEMBERS',$thisClass)">
                       <xsl:apply-templates select="." mode="classmember">
                         <xsl:with-param name="suffix" select="$type"/>
-			<xsl:with-param name="theClass" select="$thisClass"/>
+                        <xsl:with-param name="theClass" select="$thisClass"/>
                       </xsl:apply-templates>
                     </xsl:for-each>
                   </choice>
@@ -788,12 +788,12 @@ select="$makeDecls"/></xsl:message>
     <xsl:param name="suffix"/>
     <xsl:variable name="localprefix">
       <xsl:choose>
-	<xsl:when test="@prefix">
-	  <xsl:value-of select="@prefix"/>
-	</xsl:when>
-	<xsl:otherwise>
-	  <xsl:value-of select="$generalPrefix"/>
-	</xsl:otherwise>
+        <xsl:when test="@prefix">
+          <xsl:value-of select="@prefix"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$generalPrefix"/>
+        </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
 
@@ -803,7 +803,7 @@ select="$makeDecls"/></xsl:message>
       </xsl:when>
       <xsl:otherwise>
         <ref xmlns="http://relaxng.org/ns/structure/1.0"
-	     name="{$localprefix}{@ident}_{$suffix}"/>
+             name="{$localprefix}{@ident}_{$suffix}"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -1011,13 +1011,13 @@ select="$makeDecls"/></xsl:message>
           </xsl:when>
           <xsl:when test="tei:content/*">
             <xsl:apply-templates
-		select="tei:content/*|tei:content/processing-instruction()"
-		mode="tangle"/>
+                select="tei:content/*|tei:content/processing-instruction()"
+                mode="tangle"/>
           </xsl:when>
-	  <xsl:when test="tei:content/processing-instruction()">
+          <xsl:when test="tei:content/processing-instruction()">
             <xsl:apply-templates
-		select="tei:content/processing-instruction()" mode="tangle"/>
-	  </xsl:when>
+                select="tei:content/processing-instruction()" mode="tangle"/>
+          </xsl:when>
         </xsl:choose>
       </TEMPTREE>
     </xsl:variable>
@@ -1043,7 +1043,7 @@ select="$makeDecls"/></xsl:message>
         </value>
         <xsl:if test="not($oddmode='tei')">
           <a:documentation>
-	    <xsl:sequence select="tei:makeDescription(., true(), true())"/>
+            <xsl:sequence select="tei:makeDescription(., true(), true())"/>
           </a:documentation>
         </xsl:if>
       </xsl:for-each>
@@ -1068,8 +1068,8 @@ select="$makeDecls"/></xsl:message>
 
   <xsl:template match="tei:index">
       <xsl:call-template name="makeAnchor">
-	<xsl:with-param name="name">IDX-<xsl:number level="any"/>
-	</xsl:with-param>
+        <xsl:with-param name="name">IDX-<xsl:number level="any"/>
+        </xsl:with-param>
       </xsl:call-template>
   </xsl:template>
 
@@ -1304,7 +1304,7 @@ select="$makeDecls"/></xsl:message>
     <xsl:comment>Start of import of <xsl:value-of select="@href"/></xsl:comment>
     <div xmlns="http://relaxng.org/ns/structure/1.0">
     <xsl:for-each
-	  select="doc(resolve-uri(@href,base-uri(/)))/rng:grammar">
+          select="doc(resolve-uri(@href,base-uri(/)))/rng:grammar">
         <xsl:apply-templates mode="expandRNG" select="@*|node()">
           <xsl:with-param name="prefix" select="$prefix"/>
         </xsl:apply-templates>
@@ -1486,7 +1486,7 @@ select="$makeDecls"/></xsl:message>
       </xsl:if>
       <xsl:if test="not($oddmode='tei')">
         <a:documentation>
-	  <xsl:sequence select="tei:makeDescription(., true(), true())"/>
+          <xsl:sequence select="tei:makeDescription(., true(), true())"/>
         </a:documentation>
       </xsl:if>
       <xsl:variable name="minmax" select="tei:minOmaxO( tei:datatype/@minOccurs, tei:datatype/@maxOccurs )"/>
@@ -1777,17 +1777,17 @@ select="$makeDecls"/></xsl:message>
       <xsl:with-param name="grammar">true</xsl:with-param>
       <xsl:with-param name="content">
         <Wrapper>
-	  <xsl:variable name="c">
-	    <xsl:choose>
-	      <xsl:when test="@prefix">
-		<xsl:value-of select="@prefix"/>
-	      </xsl:when>
-	      <xsl:otherwise>
-		<xsl:value-of select="$generalPrefix"/>
-	      </xsl:otherwise>
-	    </xsl:choose>
-	    <xsl:value-of select="@ident"/>
-	  </xsl:variable>
+          <xsl:variable name="c">
+            <xsl:choose>
+              <xsl:when test="@prefix">
+                <xsl:value-of select="@prefix"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="$generalPrefix"/>
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:value-of select="@ident"/>
+          </xsl:variable>
           <define xmlns="http://relaxng.org/ns/structure/1.0" combine="choice"
             name="{$c}.attributes">
             <empty xmlns="http://relaxng.org/ns/structure/1.0"/>
@@ -1862,49 +1862,33 @@ select="$makeDecls"/></xsl:message>
 
   <xsl:template name="makeTEIVersion">
     <xsl:choose>
-      <xsl:when test="ancestor-or-self::tei:TEI/processing-instruction()[name()='TEIVERSION']">
+      <xsl:when test="ancestor-or-self::tei:TEI/processing-instruction()[name() eq 'TEIVERSION']">
         <!-- JC Additions to form proper URL from version number -->
-       <!--   MH and SB: Note that this PI is created during odd2odd.xsl, and used to store version 
-                  information from p5subset.xml. -->
-        <xsl:variable name="TEIVersion"
-          select="ancestor-or-self::tei:TEI/processing-instruction()[name()='TEIVERSION'][1]"/>
-        <xsl:variable name="TEIVersion-edition"
-          select="substring-before($TEIVersion, ' Last')"/>
-        <xsl:variable name="TEIVersion-datestring"
-          select="concat(' Last',substring-after($TEIVersion, ' Last'))"/>
-        <xsl:variable name="TEIVersionWithoutFullStop">
-          <xsl:choose>
-            <xsl:when
-              test="substring($TEIVersion-edition,
-              string-length($TEIVersion-edition)) =
-              '.' and matches($TEIVersion-edition, '\d\d*\.\d\d*\.\d\d*\.')">
-              <xsl:value-of
-                select="substring($TEIVersion-edition,0,string-length($TEIVersion-edition))"
-              />
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="$TEIVersion-edition"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
-        <xsl:variable name="versionURL"
-          select="concat('https://www.tei-c.org/Vault/P5/', $TEIVersionWithoutFullStop, '/')"/>
-        <xsl:text>&#10;TEI Edition: </xsl:text>
-        <xsl:value-of select="$TEIVersion"/>
-        <xsl:text>&#10;TEI Edition Location: </xsl:text>
-        <xsl:value-of select="$versionURL"/>
-        <xsl:text>&#10;</xsl:text>
-        </xsl:when>
-      <xsl:when
-        test="ancestor-or-self::tei:TEI/tei:teiHeader/tei:fileDesc/tei:editionStmt/tei:edition">
-        <xsl:text>&#10;Edition: </xsl:text>
-        <xsl:value-of
-          select="ancestor-or-self::tei:TEI/tei:teiHeader/tei:fileDesc/tei:editionStmt/tei:edition"/>
-        <xsl:text>&#10;</xsl:text>
+        <!-- MH and SB: Note that this PI is created during odd2odd.xsl, and used to store version 
+             information from p5subset.xml. -->
+        <!-- SB modified 2023-05-01 —
+          * Simplify code
+          * Correctly extract only the version number itself per ticket #607
+            - But note that it is quite fragile, in that it is searching for a very particular string
+          * Normalize space of “TEI Edition” output so it is all on one line
+        -->
+        <xsl:variable name="TEIVersion" select="ancestor-or-self::tei:TEI/processing-instruction()[name() eq 'TEIVERSION'][1]"/>
+        <xsl:variable name="TEIVersion-edition" select="substring-before( $TEIVersion, ' Last')"/>
+        <xsl:variable name="TEIVersion-datestring" select="concat(' Last', substring-after( $TEIVersion, ' Last') )"/>
+        <xsl:variable name="TEIVersion-only" select="replace( $TEIVersion-edition, '^P5 Version&#xA0;(\d+\.\d+\.\d+[abABɑΑΒβ]?)\.$', '$1')"/>
+        <xsl:variable name="versionURL" select="concat( $defaultTEIServer, $TEIVersion-only, '/')"/>
+        <xsl:sequence select="'&#x0A;TEI Edition: '||normalize-space($TEIVersion)"/>
+        <xsl:sequence select="'&#x0A;TEI Edition Location: '||$versionURL"/>
+        <xsl:text>&#x0A;</xsl:text>
+      </xsl:when>
+      <xsl:when test="ancestor-or-self::tei:TEI/tei:teiHeader/tei:fileDesc/tei:editionStmt/tei:edition">
+        <xsl:text>&#x0A;Edition: </xsl:text>
+        <xsl:value-of select="ancestor-or-self::tei:TEI/tei:teiHeader/tei:fileDesc/tei:editionStmt/tei:edition"/>
+        <xsl:text>&#x0A;</xsl:text>
       </xsl:when>
     </xsl:choose>
   </xsl:template>
-
+  
   <!-- process <gloss> and <desc> to make title= attribute values -->
   <xsl:template match="tei:gloss" mode="glossDescTitle">
     <!-- At the moment the only descendants of a <gloss> that appears in <elementSpec> or <classSpec> -->
@@ -1914,8 +1898,8 @@ select="$makeDecls"/></xsl:message>
   </xsl:template>
   <xsl:template match="tei:desc" mode="glossDescTitle">
     <!-- 
-	 As of 2014-08-12, revision 12970, the only descendants of a
-	 <desc> that appears in an <elementSpec> or a <classSpec> are:
+         As of 2014-08-12, revision 12970, the only descendants of a
+         <desc> that appears in an <elementSpec> or a <classSpec> are:
            329 gi
             79 term
             68 att
@@ -1929,13 +1913,13 @@ select="$makeDecls"/></xsl:message>
              1 title
          You might think that from here we can just <apply-templates>
          and be done with it. But if we do that, we end up with an infinite-
-	 loop of called templates problem. To wit, inside the <desc> we are
-	 processing there are (e.g.) <gi> elements. They get caught by a
-	 template in html/html_oddprocessing.xsl, which goes about calling
-	 linkTogether, which goes about applying templates (in mode glossDesc)
-	 to the <elementSpec> that defines the element mentioned in the content
-	 of the <gi>. That, in turn, would apply templates to the <desc> that
-	 we started with.
+         loop of called templates problem. To wit, inside the <desc> we are
+         processing there are (e.g.) <gi> elements. They get caught by a
+         template in html/html_oddprocessing.xsl, which goes about calling
+         linkTogether, which goes about applying templates (in mode glossDesc)
+         to the <elementSpec> that defines the element mentioned in the content
+         of the <gi>. That, in turn, would apply templates to the <desc> that
+         we started with.
     -->
     <xsl:apply-templates mode="#current"/>
   </xsl:template>
@@ -1990,28 +1974,28 @@ select="$makeDecls"/></xsl:message>
           <xsl:attribute name="id" select="tei:makePatternID(.)"/>
           <rule>
             <xsl:attribute name="context">
-	      <xsl:choose>
-		<!-- in <attDef> in <elementSpec>: -->
-		<xsl:when test="ancestor::tei:attDef/ancestor::tei:elementSpec">
-		  <xsl:sequence select="tei:generate-nsprefix-schematron(.)"/>
-		  <xsl:value-of select="ancestor::tei:elementSpec/@ident"/>
-		  <xsl:text>/@</xsl:text>
-		  <xsl:value-of select="ancestor::tei:attDef/@ident"/>
-		  <xsl:text></xsl:text> <!-- what does this do? —Syd, 2020-02-15 -->
-		</xsl:when>
-		<!-- in <attDef> in something else: -->
-		<xsl:when test="ancestor::tei:attDef">
-		  <xsl:text>@</xsl:text>
-		  <xsl:value-of select="ancestor::tei:attDef/@ident"/>
-		</xsl:when>		  
-		<xsl:otherwise>
-		  <!-- ?? I guess we figure we must be in an
-		       <elementSpec>, but I am not at all convinced
-		       that is necessarily true. —Syd, 2020-02-15 -->
-		  <xsl:sequence select="tei:generate-nsprefix-schematron(.)"/>
-		  <xsl:value-of select="ancestor::tei:elementSpec/@ident"/>
-		</xsl:otherwise>
-	      </xsl:choose>
+              <xsl:choose>
+                <!-- in <attDef> in <elementSpec>: -->
+                <xsl:when test="ancestor::tei:attDef/ancestor::tei:elementSpec">
+                  <xsl:sequence select="tei:generate-nsprefix-schematron(.)"/>
+                  <xsl:value-of select="ancestor::tei:elementSpec/@ident"/>
+                  <xsl:text>/@</xsl:text>
+                  <xsl:value-of select="ancestor::tei:attDef/@ident"/>
+                  <xsl:text></xsl:text> <!-- what does this do? —Syd, 2020-02-15 -->
+                </xsl:when>
+                <!-- in <attDef> in something else: -->
+                <xsl:when test="ancestor::tei:attDef">
+                  <xsl:text>@</xsl:text>
+                  <xsl:value-of select="ancestor::tei:attDef/@ident"/>
+                </xsl:when>               
+                <xsl:otherwise>
+                  <!-- ?? I guess we figure we must be in an
+                       <elementSpec>, but I am not at all convinced
+                       that is necessarily true. —Syd, 2020-02-15 -->
+                  <xsl:sequence select="tei:generate-nsprefix-schematron(.)"/>
+                  <xsl:value-of select="ancestor::tei:elementSpec/@ident"/>
+                </xsl:otherwise>
+              </xsl:choose>
             </xsl:attribute>
             <xsl:apply-templates mode="justcopy" select="parent::*/(sch:let|sch:assert|sch:report)"/>
           </rule>
@@ -2019,7 +2003,7 @@ select="$makeDecls"/></xsl:message>
       </xsl:when>
       <xsl:when test="self::sch:assert|self::sch:report"/>  <!-- processed immediately above -->
       <xsl:otherwise>
-	<xsl:apply-templates mode="justcopy" select="parent::*/sch:let|."/>
+        <xsl:apply-templates mode="justcopy" select="parent::*/sch:let|."/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -2035,10 +2019,10 @@ select="$makeDecls"/></xsl:message>
     <xsl:param name="e"/>
     <xsl:for-each select="$e">
       <xsl:sequence select="concat(
-	if (@ns='http://www.tei-c.org/ns/1.0') then ''
-	else if (@ns) then @ns
-	else if (ancestor::tei:schemaSpec/@ns) then
-	ancestor::tei:schemaSpec/@ns else '',@ident)"/>
+        if (@ns='http://www.tei-c.org/ns/1.0') then ''
+        else if (@ns) then @ns
+        else if (ancestor::tei:schemaSpec/@ns) then
+        ancestor::tei:schemaSpec/@ns else '',@ident)"/>
     </xsl:for-each>
   </xsl:function>
 
@@ -2062,21 +2046,21 @@ select="$makeDecls"/></xsl:message>
    <xsl:template match="*" mode="justcopy">
      <xsl:copy>
          <xsl:apply-templates
-	     select="*|@*|processing-instruction()|text()" mode="justcopy"/>
+             select="*|@*|processing-instruction()|text()" mode="justcopy"/>
      </xsl:copy>
    </xsl:template>
 
    <xsl:template match="a:*" mode="justcopy">
      <xsl:element namespace="http://relaxng.org/ns/compatibility/annotations/1.0" name="{name()}">
          <xsl:apply-templates
-	     select="*|@*|processing-instruction()|text()" mode="justcopy"/>
+             select="*|@*|processing-instruction()|text()" mode="justcopy"/>
       </xsl:element>
    </xsl:template>
 
    <xsl:template match="rng:*" mode="justcopy">
      <xsl:element namespace="http://relaxng.org/ns/structure/1.0" name="{local-name()}">
        <xsl:apply-templates
-	   select="*|@*|processing-instruction()|text()" mode="justcopy"/>
+           select="*|@*|processing-instruction()|text()" mode="justcopy"/>
      </xsl:element>
    </xsl:template>
 
@@ -2183,7 +2167,7 @@ select="$makeDecls"/></xsl:message>
         </xsl:when>
         <xsl:when test="@expand='sequenceRepeatable'">
           <xsl:for-each select="key('CLASSMEMBERS',$this)">
-            <xsl:if test="tei:includeMember(@ident,$except,$include)">	      
+            <xsl:if test="tei:includeMember(@ident,$except,$include)">        
               <oneOrMore xmlns="http://relaxng.org/ns/structure/1.0">
                 <xsl:apply-templates select="." mode="classmember">
                   <xsl:with-param name="theClass" select="$this"/>
@@ -2195,7 +2179,7 @@ select="$makeDecls"/></xsl:message>
         </xsl:when>
         <xsl:when test="@expand='sequenceOptionalRepeatable'">
           <xsl:for-each select="key('CLASSMEMBERS',$this)">
-            <xsl:if test="tei:includeMember(@ident,$except,$include)">	      
+            <xsl:if test="tei:includeMember(@ident,$except,$include)">        
               <zeroOrMore xmlns="http://relaxng.org/ns/structure/1.0">
                 <xsl:apply-templates select="." mode="classmember">
                   <xsl:with-param name="suffix" select="@expand"/>
@@ -2332,22 +2316,22 @@ select="$makeDecls"/></xsl:message>
     <xsl:variable name="result">
     <xsl:for-each select="$context">
       <xsl:for-each select="key('IDENTS',@class)">
-	<xsl:choose>
-	  <xsl:when test="@prefix">
-	    <xsl:value-of select="@prefix"/>
-	  </xsl:when>
-	  <xsl:otherwise>
-	    <xsl:value-of select="$prefix"/>
-	  </xsl:otherwise>
-	</xsl:choose>
+        <xsl:choose>
+          <xsl:when test="@prefix">
+            <xsl:value-of select="@prefix"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$prefix"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:for-each>
       <xsl:choose>
-	<xsl:when test="not(@name)">
-	  <xsl:value-of select="concat(@class,'.attributes')"/>
-	</xsl:when>
-	<xsl:otherwise>
-	  <xsl:value-of select="concat(@class,'.attribute.',translate(@name,':',''))"/>
-	</xsl:otherwise>
+        <xsl:when test="not(@name)">
+          <xsl:value-of select="concat(@class,'.attributes')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat(@class,'.attribute.',translate(@name,':',''))"/>
+        </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
     </xsl:variable>
@@ -2374,40 +2358,40 @@ select="$makeDecls"/></xsl:message>
   <xsl:function name="tei:generateRefPrefix" as="xs:string">
     <xsl:param name="context"/>
     <!-- where we meet a pointer, we have a choice of how to proceed
-	 
-	 a) if there is no auto-prefixing, just use as is
-	 b) if the thing exists in the IDENTS table (which includes prefixes), and starts with the prefix, then use it as is
-	 c) if it exists in the IDENTS table and has a prefix, use that
-	 d) otherwise, if it exists in the IDENTS table use the general prefix
-	 e) otherwise, just use what we are given
+         
+         a) if there is no auto-prefixing, just use as is
+         b) if the thing exists in the IDENTS table (which includes prefixes), and starts with the prefix, then use it as is
+         c) if it exists in the IDENTS table and has a prefix, use that
+         d) otherwise, if it exists in the IDENTS table use the general prefix
+         e) otherwise, just use what we are given
     -->
     <xsl:for-each select="$context">
       <xsl:variable name="lookup" select="replace(@name|@key,'_(alternation|sequenceOptionalRepeatable|sequenceOptional|sequenceRepeatable|sequence)','')"/>
       <xsl:variable name="myprefix"
-		    select="ancestor::*[@prefix][1]/@prefix"/>
+                    select="ancestor::*[@prefix][1]/@prefix"/>
       <xsl:variable name="fullname" select="@name|@key"/>
       <xsl:choose>
-	<xsl:when test="ancestor::tei:content[@autoPrefix='false']">
-	  <xsl:value-of select="$fullname"/>
-	</xsl:when>
-	<xsl:when test="key('IDENTS',$lookup)">
-	  <xsl:for-each select="key('IDENTS',$lookup)[1]">
-	    <xsl:choose>
-	      <xsl:when test="@prefix and starts-with($fullname,@prefix)">
-		<xsl:value-of select="$fullname"/>
-	      </xsl:when>
-	      <xsl:when test="@prefix">
-		<xsl:value-of select="concat(@prefix,$fullname)"/>
-	      </xsl:when>
-	      <xsl:otherwise>
-		<xsl:value-of select="concat($generalPrefix,$fullname)"/>
-	      </xsl:otherwise>
-	    </xsl:choose>
-	  </xsl:for-each>
-	</xsl:when>
-	<xsl:otherwise>
-	  <xsl:value-of select="$fullname"/>
-	</xsl:otherwise>
+        <xsl:when test="ancestor::tei:content[@autoPrefix='false']">
+          <xsl:value-of select="$fullname"/>
+        </xsl:when>
+        <xsl:when test="key('IDENTS',$lookup)">
+          <xsl:for-each select="key('IDENTS',$lookup)[1]">
+            <xsl:choose>
+              <xsl:when test="@prefix and starts-with($fullname,@prefix)">
+                <xsl:value-of select="$fullname"/>
+              </xsl:when>
+              <xsl:when test="@prefix">
+                <xsl:value-of select="concat(@prefix,$fullname)"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="concat($generalPrefix,$fullname)"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$fullname"/>
+        </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
   </xsl:function>
@@ -2417,11 +2401,11 @@ select="$makeDecls"/></xsl:message>
     <xsl:param name="exc" />
     <xsl:param name="inc" />
       <xsl:choose>
-	<xsl:when test="not($exc) and not($inc)">true</xsl:when>
-	<xsl:when test="$inc and $ident cast as xs:string  = tokenize($inc, ' ')">true</xsl:when>
-	<xsl:when test="$inc">false</xsl:when>
-	<xsl:when test="$exc and $ident cast as xs:string = tokenize($exc, ' ')">false</xsl:when>
-	<xsl:otherwise>true</xsl:otherwise>
+        <xsl:when test="not($exc) and not($inc)">true</xsl:when>
+        <xsl:when test="$inc and $ident cast as xs:string  = tokenize($inc, ' ')">true</xsl:when>
+        <xsl:when test="$inc">false</xsl:when>
+        <xsl:when test="$exc and $ident cast as xs:string = tokenize($exc, ' ')">false</xsl:when>
+        <xsl:otherwise>true</xsl:otherwise>
       </xsl:choose>
   </xsl:function>
 


### PR DESCRIPTION
With @trishaoconnor, change the "makeTEIVersion" template in odds/teiodds.xsl so that
 a) it does not output the string “P5 Version&#x0A;” (or “Version&#x0A;”) as part of the version URL; and
 b) it outputs the version information on 1 line instead of two.

The good news is that I am quite confident that the new code works, in that it generates the expected output. The bad news is I have no idea if the expected output (since it is slightly different from the previous output) might break something that the build process did not test. (I have fixed the actual Test procedure, and Test2 passed without any problem.)

Warning to reviewers: I have also changed a whole bunch of whitespace, so be sure to ask GitHub to hide whitespace changes when you examine the changes. And I daresay the only file you really want to examine is teiodds.xsl. (All other changes are just fallout from changes to that file.)