### PR TITLE
process `@xml:id` wherever the output of a <list> is generated

### DIFF
--- a/html/html_core.xsl
+++ b/html/html_core.xsl
@@ -649,6 +649,7 @@ of this software, even if advised of the possibility of such damage.
       <xsl:when test="@type='catalogue'">
         <p>
           <dl>
+	    <xsl:apply-templates select="@xml:id"/>
             <xsl:call-template name="makeRendition">
               <xsl:with-param name="default">false</xsl:with-param>
             </xsl:call-template>
@@ -665,6 +666,7 @@ of this software, even if advised of the possibility of such damage.
         </xsl:variable>
         <p>
           <table>
+	    <xsl:apply-templates select="@xml:id"/>
             <xsl:call-template name="makeRendition">
               <xsl:with-param name="default">false</xsl:with-param>
             </xsl:call-template>
@@ -685,6 +687,7 @@ of this software, even if advised of the possibility of such damage.
       </xsl:when>
       <xsl:when test="tei:isGlossList(.)">
         <dl>
+	  <xsl:apply-templates select="@xml:id"/>
           <xsl:call-template name="makeRendition">
             <xsl:with-param name="default">false</xsl:with-param>
           </xsl:call-template>
@@ -694,6 +697,7 @@ of this software, even if advised of the possibility of such damage.
       </xsl:when>
       <xsl:when test="tei:isGlossTable(.)">
         <table>
+	  <xsl:apply-templates select="@xml:id"/>
           <xsl:call-template name="makeRendition">
             <xsl:with-param name="default">false</xsl:with-param>
           </xsl:call-template>
@@ -706,6 +710,7 @@ of this software, even if advised of the possibility of such damage.
       </xsl:when>
       <xsl:when test="@type='inline' or @type='runin'">
         <p>
+	  <xsl:apply-templates select="@xml:id"/>
           <xsl:apply-templates select="*[not(self::tei:head or self::tei:trailer)]"  mode="inline"/>
         </p>
       </xsl:when>
@@ -714,6 +719,7 @@ of this software, even if advised of the possibility of such damage.
       </xsl:when>
       <xsl:otherwise>
         <xsl:element name="{if (tei:isOrderedList(.)) then 'ol' else 'ul'}">
+	  <xsl:apply-templates select="@xml:id"/>
           <xsl:call-template name="makeRendition">
             <xsl:with-param name="default">false</xsl:with-param>
           </xsl:call-template>


### PR DESCRIPTION
I am hoping this fixes #616 …
Relatively minor update to html/html_core.xsl: Just added a call to process the `@xml:id` attribute to each of the possible output elements generated for `<list>`. Just chose one when two elements were generated (despite my comment on the ticket : -).
My main surprise is that the tests all seemed to pass on my system. I would have expected diff errors when a test input file had a `<list xml:id="DUCK">` whose output used to be `<ul>` but is now `<ul id="DUCK">`. Harumph. 