### PR TITLE
Adding templates for val and tag to fix #567

### DIFF
--- a/Test2/build.xml
+++ b/Test2/build.xml
@@ -105,7 +105,7 @@
       without special parameters. -->
     <fileset id="simpleTeiForHtmlFiles" dir="${inputDir}" includes="testP5ExTcp1.xml, 
         testRendition1.xml, testQuotations1.xml, testWhitespace1.xml, testBinaryObjects1.xml,
-        testCorpus1.xml, testMathML.xml, testStructure1.xml, test-382.xml"/>
+        testCorpus1.xml, testMathML.xml, testStructure1.xml, test-382.xml, testPhrase.xml"/>
     
 <!--  HTML input files for conversion into TEI.  -->
     <fileset id="htmlInputFiles" dir="${inputDir}" includes="testHtmlInput1.html"/>

--- a/html/html.xsl
+++ b/html/html.xsl
@@ -225,6 +225,8 @@ of this software, even if advised of the possibility of such damage.
       <xsl:call-template name="microdata"/>
     </xsl:if>
   </xsl:template>
+  
+  
 
 
 
@@ -426,6 +428,29 @@ of this software, even if advised of the possibility of such damage.
       <xsl:value-of select="$after"/>
     </xsl:element>
   </xsl:template>
+  
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>[html] creates a span with a class of delim (and optionally others) to wrap
+      delimiting text to allow users to remove/hide delimiters for whatever reason
+      (e.g. to use CSS pseudo elements instead).</desc>
+    <param name="string">The text content of the delimiter (e.g. &lt;)</param>
+    <param name="classes">A sequence of additional class names to be added to
+      the produced span. (e.g. "start")</param>
+    <return>A span element containing a delimiter:
+      <pre>
+      &lt;span class="delim start"&gt;{{{{&lt;/span&gt;
+    </pre>
+    </return>
+  </doc>
+  <xsl:template name="makeDelimiter">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:param name="classes" as="xs:string*"/>
+    <xsl:element name="span">
+      <xsl:attribute name="class" select="string-join(('delim', $classes),' ')"/>
+      <xsl:sequence select="$string"/>
+    </xsl:element>
+  </xsl:template>
+  
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
     <desc>how to make a horizontal rule</desc>

--- a/html/html_core.xsl
+++ b/html/html_core.xsl
@@ -325,95 +325,6 @@ of this software, even if advised of the possibility of such damage.
       </xsl:choose>
     </xsl:element>
   </xsl:template>
-  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
-    <desc>
-      <p>Process element att</p>
-      <p>
-        <p xmlns="http://www.w3.org/1999/xhtml"> special purpose </p>
-      </p>
-    </desc>
-  </doc>
-  <xsl:template match="tei:att">
-    <span>
-      <xsl:call-template name="makeRendition"/>
-<!--      <xsl:call-template name="makeDelimiter">
-        <xsl:with-param name="string" as="xs:string">@</xsl:with-param>
-      </xsl:call-template>-->
-      <xsl:apply-templates/>
-    </span>
-  </xsl:template>
-  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
-    <desc>
-      <p>Process element val</p>
-      <p>
-        <p xmlns="http://www.w3.org/1999/xhtml"> special purpose </p>
-      </p>
-    </desc>
-  </doc>
-  <xsl:template match="tei:val">
-    <span>
-      <xsl:call-template name="makeRendition"/>
-      <xsl:call-template name="makeDelimiter">
-        <xsl:with-param name="string" as="xs:string">"</xsl:with-param>
-        <xsl:with-param name="classes" select="'start'"/>
-      </xsl:call-template>
-      <xsl:apply-templates/>
-      <xsl:call-template name="makeDelimiter">
-        <xsl:with-param name="string" as="xs:string">"</xsl:with-param>
-        <xsl:with-param name="classes" select="'end'"/>
-      </xsl:call-template>
-    </span>
-  </xsl:template>
-  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
-    <desc>
-      <p>Process element tag</p>
-      <p>
-        <p xmlns="http://www.w3.org/1999/xhtml"> special purpose </p>
-      </p>
-    </desc>
-  </doc>
-  <xsl:template match="tei:tag">
-    <xsl:variable name="delims" as="xs:string+">
-      <xsl:choose>
-        <xsl:when test="empty(@type)">
-          <xsl:sequence select="( '&lt;', '&gt;' )"/>
-        </xsl:when>
-        <xsl:when test="@type = 'start'">
-          <xsl:sequence select="( '&lt;', '&gt;' )"/>
-        </xsl:when>
-        <xsl:when test="@type = 'end'">
-          <xsl:sequence select="( '&lt;/', '&gt;' )"/>
-        </xsl:when>
-        <xsl:when test="@type eq 'empty'">
-          <xsl:sequence select="( '&lt;', '/&gt;' )"/>
-        </xsl:when>
-        <xsl:when test="@type eq 'pi'">
-          <xsl:sequence select="( '&lt;?', '?/&gt;' )"/>
-        </xsl:when>
-        <xsl:when test="@type eq 'comment'">
-          <xsl:sequence select="( '&lt;!--', '--&gt;' )"/>
-        </xsl:when>
-        <xsl:when test="@type eq 'ms'">
-          <xsl:sequence select="( '&lt;[CDATA[', ']]&gt;' )"/>
-        </xsl:when>
-      </xsl:choose>
-    </xsl:variable>
-    <span>
-      <xsl:attribute name="class" select="string-join( ( local-name(), @type, @scheme ),' ' )"/>
-      <xsl:call-template name="makeRendition">
-        <xsl:with-param name="default" select="'false'"/>
-      </xsl:call-template>
-      <xsl:call-template name="makeDelimiter">
-        <xsl:with-param name="string" select="$delims[1]" as="xs:string"/>
-        <xsl:with-param name="classes" select="'start'"/>
-      </xsl:call-template>
-      <xsl:apply-templates/>
-      <xsl:call-template name="makeDelimiter">
-        <xsl:with-param name="string" select="$delims[2]" as="xs:string"/>
-        <xsl:with-param name="classes" select="'end'"/>
-      </xsl:call-template>
-    </span>
-  </xsl:template>
   
   
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
@@ -1864,27 +1775,8 @@ of this software, even if advised of the possibility of such damage.
       <xsl:apply-templates/>
     </xsl:element>
   </xsl:template>
-  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
-    <desc>[html] creates a span with a class of delim (and optionally others) to wrap
-    delimiting text to allow users to remove/hide delimiters for whatever reason
-    (e.g. to use CSS pseudo elements instead).</desc>
-    <param name="string">The text content of the delimiter (e.g. &lt;)</param>
-    <param name="classes">A sequence of additional class names to be added to
-    the produced span. (e.g. "start")</param>
-    <return>A span element containing a delimiter:
-    <pre>
-      &lt;span class="delim start"&gt;{{{{&lt;/span&gt;
-    </pre>
-    </return>
-  </doc>
-  <xsl:template name="makeDelimiter">
-    <xsl:param name="string" as="xs:string"/>
-    <xsl:param name="classes" as="xs:string*"/>
-    <xsl:element name="span">
-      <xsl:attribute name="class" select="string-join(('delim', $classes),' ')"/>
-      <xsl:sequence select="$string"/>
-    </xsl:element>
-  </xsl:template>
+
+
   <xsl:template name="microdata"/>
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">

--- a/html/html_core.xsl
+++ b/html/html_core.xsl
@@ -336,9 +336,86 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:att">
     <span>
       <xsl:call-template name="makeRendition"/>
+<!--      <xsl:call-template name="makeDelimiter">
+        <xsl:with-param name="string" as="xs:string">@</xsl:with-param>
+      </xsl:call-template>-->
       <xsl:apply-templates/>
     </span>
   </xsl:template>
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>
+      <p>Process element val</p>
+      <p>
+        <p xmlns="http://www.w3.org/1999/xhtml"> special purpose </p>
+      </p>
+    </desc>
+  </doc>
+  <xsl:template match="tei:val">
+    <span>
+      <xsl:call-template name="makeRendition"/>
+      <xsl:call-template name="makeDelimiter">
+        <xsl:with-param name="string" as="xs:string">"</xsl:with-param>
+        <xsl:with-param name="classes" select="'start'"/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <xsl:call-template name="makeDelimiter">
+        <xsl:with-param name="string" as="xs:string">"</xsl:with-param>
+        <xsl:with-param name="classes" select="'end'"/>
+      </xsl:call-template>
+    </span>
+  </xsl:template>
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>
+      <p>Process element tag</p>
+      <p>
+        <p xmlns="http://www.w3.org/1999/xhtml"> special purpose </p>
+      </p>
+    </desc>
+  </doc>
+  <xsl:template match="tei:tag">
+    <xsl:variable name="delims" as="xs:string+">
+      <xsl:choose>
+        <xsl:when test="empty(@type)">
+          <xsl:sequence select="( '&lt;', '&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type = 'start'">
+          <xsl:sequence select="( '&lt;', '&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type = 'end'">
+          <xsl:sequence select="( '&lt;/', '&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type eq 'empty'">
+          <xsl:sequence select="( '&lt;', '/&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type eq 'pi'">
+          <xsl:sequence select="( '&lt;?', '?/&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type eq 'comment'">
+          <xsl:sequence select="( '&lt;!--', '--&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type eq 'ms'">
+          <xsl:sequence select="( '&lt;[CDATA[', ']]&gt;' )"/>
+        </xsl:when>
+      </xsl:choose>
+    </xsl:variable>
+    <span>
+      <xsl:attribute name="class" select="string-join( ( local-name(), @type, @scheme ),' ' )"/>
+      <xsl:call-template name="makeRendition">
+        <xsl:with-param name="default" select="'false'"/>
+      </xsl:call-template>
+      <xsl:call-template name="makeDelimiter">
+        <xsl:with-param name="string" select="$delims[1]" as="xs:string"/>
+        <xsl:with-param name="classes" select="'start'"/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <xsl:call-template name="makeDelimiter">
+        <xsl:with-param name="string" select="$delims[2]" as="xs:string"/>
+        <xsl:with-param name="classes" select="'end'"/>
+      </xsl:call-template>
+    </span>
+  </xsl:template>
+  
+  
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
     <desc>Process gloss element</desc>
   </doc>
@@ -1785,6 +1862,27 @@ of this software, even if advised of the possibility of such damage.
     <xsl:element name="{if (not(tei:isInline(.))) then 'div' else 'span'}">
       <xsl:call-template name="makeRendition"/>
       <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>[html] creates a span with a class of delim (and optionally others) to wrap
+    delimiting text to allow users to remove/hide delimiters for whatever reason
+    (e.g. to use CSS pseudo elements instead).</desc>
+    <param name="string">The text content of the delimiter (e.g. &lt;)</param>
+    <param name="classes">A sequence of additional class names to be added to
+    the produced span. (e.g. "start")</param>
+    <return>A span element containing a delimiter:
+    <pre>
+      &lt;span class="delim start"&gt;{{{{&lt;/span&gt;
+    </pre>
+    </return>
+  </doc>
+  <xsl:template name="makeDelimiter">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:param name="classes" as="xs:string*"/>
+    <xsl:element name="span">
+      <xsl:attribute name="class" select="string-join(('delim', $classes),' ')"/>
+      <xsl:sequence select="$string"/>
     </xsl:element>
   </xsl:template>
   <xsl:template name="microdata"/>

--- a/html/html_tagdocs.xsl
+++ b/html/html_tagdocs.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsl:stylesheet  xmlns="http://www.w3.org/1999/xhtml" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:teix="http://www.tei-c.org/ns/Examples" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="html a fo rng tei teix" version="2.0">
+<xsl:stylesheet  xmlns="http://www.w3.org/1999/xhtml" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"                 xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:teix="http://www.tei-c.org/ns/Examples" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="html a fo rng tei teix xs" version="2.0">
 
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" scope="stylesheet" type="stylesheet">
     <desc>
@@ -71,6 +71,100 @@ of this software, even if advised of the possibility of such damage.
       <xsl:text>&gt;</xsl:text>
     </span>
   </xsl:template>
+  
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>
+      <p>Process element att</p>
+    </desc>
+  </doc>
+  <xsl:template match="tei:att">
+    <span>
+      <xsl:call-template name="makeRendition"/>
+      <!-- JT (2023-09-28): At present, att's delimiter (@)
+           is generated in CSS; if that changes, then the following
+           should be included to be consistent -->
+      <!--
+        <xsl:call-template name="makeDelimiter">
+         <xsl:with-param name="string" as="xs:string">@</xsl:with-param>
+       </xsl:call-template>
+      -->
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>
+      <p>Process element val</p>
+    </desc>
+  </doc>
+  <xsl:template match="tei:val">
+    <span>
+      <xsl:call-template name="makeRendition"/>
+      <xsl:call-template name="makeDelimiter">
+        <xsl:with-param name="string" as="xs:string">"</xsl:with-param>
+        <xsl:with-param name="classes" select="'start'"/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <xsl:call-template name="makeDelimiter">
+        <xsl:with-param name="string" as="xs:string">"</xsl:with-param>
+        <xsl:with-param name="classes" select="'end'"/>
+      </xsl:call-template>
+    </span>
+  </xsl:template>
+  <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
+    <desc>
+      <p>Process element tag</p>
+    </desc>
+  </doc>
+  <xsl:template match="tei:tag">
+    <xsl:variable name="delims" as="xs:string*">
+      <xsl:choose>
+        <xsl:when test="empty(@type)">
+          <xsl:sequence select="( '&lt;', '&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type = 'start'">
+          <xsl:sequence select="( '&lt;', '&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type = 'end'">
+          <xsl:sequence select="( '&lt;/', '&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type eq 'empty'">
+          <xsl:sequence select="( '&lt;', '/&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type eq 'pi'">
+          <xsl:sequence select="( '&lt;?', '?&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type eq 'comment'">
+          <xsl:sequence select="( '&lt;!--', '--&gt;' )"/>
+        </xsl:when>
+        <xsl:when test="@type eq 'ms'">
+          <xsl:sequence select="( '&lt;[CDATA[', ']]&gt;' )"/>
+        </xsl:when>
+        <!--start, end, empty, pi, comment, and ms are the only
+            legal values (as of 4.6.0); if a different type
+            value is used, then this will break-->
+        <xsl:otherwise>
+          <xsl:message>Unhandled @type value of tei:tag: <xsl:value-of select="@type"/></xsl:message>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <span>
+      <xsl:attribute name="class" select="string-join( ( local-name(), @type, @scheme ),' ' )"/>
+      <xsl:call-template name="makeRendition">
+        <xsl:with-param name="default" select="'false'"/>
+      </xsl:call-template>
+      <xsl:call-template name="makeDelimiter">
+        <xsl:with-param name="string" select="$delims[1]" as="xs:string"/>
+        <xsl:with-param name="classes" select="'start'"/>
+      </xsl:call-template>
+      <xsl:apply-templates/>
+      <xsl:call-template name="makeDelimiter">
+        <xsl:with-param name="string" select="$delims[2]" as="xs:string"/>
+        <xsl:with-param name="classes" select="'end'"/>
+      </xsl:call-template>
+    </span>
+  </xsl:template>
+  
+  
 
 
 <xsl:template match="tei:specGrp">


### PR DESCRIPTION
* Template added to html/html_core.xsl for tag and val to transform them into spans
* Named template added to html/html_core.xsl to create a delimiter span to allow easier customization (i.e. to allow for a CSS only approach to start and end text)
* Reflect value of `@scheme` in tag's class

(See https://github.com/TEIC/Stylesheets/issues/567#issuecomment-1692355943 for additional details)
