### PR TITLE
Fix: creation of empty `attList` in  odd2odd.xsl

### DIFF
--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -970,15 +970,14 @@ of this software, even if advised of the possibility of such damage.
           </xsl:call-template>
           <!-- attList -->
           <xsl:if test="tei:attList or $ORIGINAL/tei:attList">
-              <attList xmlns="http://www.tei-c.org/ns/1.0">
-                <xsl:apply-templates mode="justcopy" select="tei:attList/@org"/>
-                <xsl:call-template name="odd2odd-processAttributes">
-                  <xsl:with-param name="ORIGINAL" select="$ORIGINAL"/>
-                  <xsl:with-param name="objectName" select="$elementName"/>
-                </xsl:call-template>
-              </attList>
+            <attList xmlns="http://www.tei-c.org/ns/1.0">
+              <xsl:apply-templates mode="justcopy" select="tei:attList/@org"/>
+              <xsl:call-template name="odd2odd-processAttributes">
+                <xsl:with-param name="ORIGINAL" select="$ORIGINAL"/>
+                <xsl:with-param name="objectName" select="$elementName"/>
+              </xsl:call-template>
+            </attList>
           </xsl:if>
-          
 
           <!-- models -->
           <xsl:choose>
@@ -1256,12 +1255,14 @@ of this software, even if advised of the possibility of such damage.
             <xsl:with-param name="elementName" select="$className"/>
           </xsl:call-template>
           <!-- attList -->
-          <attList xmlns="http://www.tei-c.org/ns/1.0">
-            <xsl:call-template name="odd2odd-processAttributes">
-              <xsl:with-param name="ORIGINAL" select="$ORIGINAL"/>
-              <xsl:with-param name="objectName" select="$className"/>
-            </xsl:call-template>
-          </attList>
+          <xsl:if test="$ORIGINAL/tei:attList">
+            <attList xmlns="http://www.tei-c.org/ns/1.0">
+              <xsl:call-template name="odd2odd-processAttributes">
+		<xsl:with-param name="ORIGINAL" select="$ORIGINAL"/>
+		<xsl:with-param name="objectName" select="$className"/>
+              </xsl:call-template>
+            </attList>
+          </xsl:if>
           <xsl:choose> <!-- maybe copy <exemplum>s from ODD or ORIGINAL -->
             <xsl:when test="$stripped='true'"/>
             <xsl:when test="tei:exemplum">

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -969,13 +969,15 @@ of this software, even if advised of the possibility of such damage.
             <xsl:with-param name="elementName" select="$elementName"/>
           </xsl:call-template>
           <!-- attList -->
-          <attList xmlns="http://www.tei-c.org/ns/1.0">
-            <xsl:apply-templates mode="justcopy" select="tei:attList/@org"/>
-            <xsl:call-template name="odd2odd-processAttributes">
-              <xsl:with-param name="ORIGINAL" select="$ORIGINAL"/>
-              <xsl:with-param name="objectName" select="$elementName"/>
-            </xsl:call-template>
-          </attList>
+          <xsl:if test="tei:attList or $ORIGINAL/tei:attList">
+              <attList xmlns="http://www.tei-c.org/ns/1.0">
+                <xsl:apply-templates mode="justcopy" select="tei:attList/@org"/>
+                <xsl:call-template name="odd2odd-processAttributes">
+                  <xsl:with-param name="ORIGINAL" select="$ORIGINAL"/>
+                  <xsl:with-param name="objectName" select="$elementName"/>
+                </xsl:call-template>
+              </attList>
+          </xsl:if>
           
 
           <!-- models -->


### PR DESCRIPTION
addresses #319

This is a local fix for `elementSpec` and probably these changes should be made in a more general way.