### PR TITLE
Fix regression: duplicate idents in `*Spec`s

### DIFF
--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -508,13 +508,16 @@ of this software, even if advised of the possibility of such damage.
   </xsl:template>
 
   <xsl:template match="tei:elementSpec[@mode eq 'change']|tei:classSpec[@mode eq 'change']|tei:macroSpec[@mode eq 'change']|tei:dataSpec[@mode eq 'change']" mode="pass0">    
+    <xsl:variable name="CURRENT_ID" select="generate-id(.)"/>
+    <xsl:variable name="CHANGED_SPECS" select="key('odd2odd-CHANGE',tei:uniqueName(.))" 
+      as="element()+"/>    
     <xsl:choose>
-      <xsl:when test="count(key('odd2odd-CHANGE',@ident))&gt;1">
+      <xsl:when test="count($CHANGED_SPECS) gt 1">
         <xsl:if
-          test="generate-id(.)=generate-id(key('odd2odd-CHANGE',@ident)[1])">
+          test="$CURRENT_ID=generate-id($CHANGED_SPECS[1])">
           <xsl:copy>
             <xsl:copy-of select="@*"/>
-            <xsl:for-each select="key('odd2odd-CHANGE',@ident)">
+            <xsl:for-each select="$CHANGED_SPECS">
               <xsl:apply-templates
                 select="*|text()|comment()|processing-instruction()"
                 mode="pass0"/>

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -510,7 +510,7 @@ of this software, even if advised of the possibility of such damage.
   <xsl:template match="tei:elementSpec[@mode eq 'change']|tei:classSpec[@mode eq 'change']|tei:macroSpec[@mode eq 'change']|tei:dataSpec[@mode eq 'change']" mode="pass0">    
     <xsl:variable name="CURRENT_ID" select="generate-id(.)"/>
     <xsl:variable name="CHANGED_SPECS" select="key('odd2odd-CHANGE',tei:uniqueName(.))" 
-      as="element()+"/>    
+      as="element()*"/>    
     <xsl:choose>
       <xsl:when test="count($CHANGED_SPECS) gt 1">
         <xsl:if


### PR DESCRIPTION
Attempting to resolve the problem of duplicate idents in specs (as mentioned in #678 and #645 and potentially others). At the time of my filing this PR, Test1 is failing (in particular, test21), so more investigation (and more testing) is required before this can be merged. 