### PR TITLE
handle `<constraintDecl>` from extract-isosch.xsl

### DIFF
--- a/Test/expected-results/test.isosch
+++ b/Test/expected-results/test.isosch
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
    <!-- DELETED TIMESTAMP. -->

--- a/odds/extract-isosch.xsl
+++ b/odds/extract-isosch.xsl
@@ -254,16 +254,21 @@ of this software, even if advised of the possibility of such damage.
       <xsl:call-template name="blockComment">
         <xsl:with-param name="content" select="'namespaces, implicit:'"/>
       </xsl:call-template>
-      <!-- Generate a sequence of all the prefix-URI pairs that we calculated in 1st pass, -->
-      <!-- separating each pair with a character we know will never occur inside (for easy -->
-      <!-- parsing later). -->
+      <!-- Generate a sequence of all the prefix-URI pairs that we
+           calculated in the 1st pass. For easy parsing later, we
+           separate each pair with a ‘␝’, which is a character we know
+           will never occur within either a namespace prefix or a
+           namespace URI (because it is not allowed in an xs:NCName,
+           and is not allowed in a URI (per RFC 3986), even though
+           xs:anyURI does not object to it). -->
       <xsl:variable name="allNSs" as="xs:string+">
         <xsl:sequence select="( $decorated//tei:*[@nsu]/concat( @nsp, '␝', @nsu ) )"/>
         <!-- if desired, other NSs can be added manually here -->
       </xsl:variable>
       <xsl:variable name="NSs" select="distinct-values( $allNSs )"/>
-      <!-- For each pair (except those that were empty, and thus are
-           now just a single ␝ character, or those thata are the XSL namespace) ... -->
+      <!-- For each pair (except those that were empty — and thus are
+           now just a single ‘␝’ character — or those that are the XSL
+           namespace) ... -->
       <xsl:for-each select="$NSs[ not( . eq '␝'  or  matches( ., '␝'||$xsl-ns||'$') ) ]">
         <xsl:sort/>
         <!-- ... parse out the prefix and the URI (using that never-occurs character) -->

--- a/odds/extract-isosch.xsl
+++ b/odds/extract-isosch.xsl
@@ -233,7 +233,7 @@ of this software, even if advised of the possibility of such damage.
   </d:doc>
   <xsl:template match="/" mode="schematron-extraction">
     <xsl:param name="decorated" as="element()"/>
-    <xsl:variable name="qb" select="( //tei:constraintDec[ @scheme eq 'schematron']/@queryBinding, 'xslt2')[1]"/>
+    <xsl:variable name="qb" select="( //tei:constraintDecl[ @scheme eq 'schematron']/@queryBinding, 'xslt2')[1]"/>
     <schema queryBinding="{$qb}">
       <title>ISO Schematron rules</title>
       <xsl:comment> This file generated <xsl:sequence select="tei:whatsTheDate()"/> by 'extract-isosch.xsl'. </xsl:comment>
@@ -262,8 +262,9 @@ of this software, even if advised of the possibility of such damage.
         <!-- if desired, other NSs can be added manually here -->
       </xsl:variable>
       <xsl:variable name="NSs" select="distinct-values( $allNSs )"/>
-      <!-- For each pair (except those that are empty or are the XSL namespace) ... -->
-      <xsl:for-each select="$NSs[ not( . eq '␝'  or  contains( ., $xsl-ns ) ) ]">
+      <!-- For each pair (except those that were empty, and thus are
+           now just a single ␝ character, or those thata are the XSL namespace) ... -->
+      <xsl:for-each select="$NSs[ not( . eq '␝'  or  matches( ., '␝'||$xsl-ns||'$') ) ]">
         <xsl:sort/>
         <!-- ... parse out the prefix and the URI (using that never-occurs character) -->
         <xsl:variable name="nsp" select="substring-before( .,':␝')"/>
@@ -546,11 +547,11 @@ of this software, even if advised of the possibility of such damage.
         <xsl:number level="any"/>
       </xsl:variable>
       <xsl:value-of
-	  select="( $scheme,
-		   'constraint',
-		    ancestor-or-self::*[@ident]/@ident/translate( .,':',''),
-		    $num )"
-	  separator="-"/>
+          select="( $scheme,
+                   'constraint',
+                    ancestor-or-self::*[@ident]/@ident/translate( .,':',''),
+                    $num )"
+          separator="-"/>
     </xsl:for-each>
   </xsl:function>
   


### PR DESCRIPTION
Addresses issue #696.
Process new `<constraintDecl>` element: use its `@queryBinding` attr, copy over its `<sch:ns>` elements into the declared NS section, and all other child elements into a new declarations section.