### PR TITLE
Improve SQF and language handling of Schematron extraction process

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -571,7 +571,7 @@ test-oddity: actual css
 		else echo "==deferring: \` diff  $(AR)/test.odd.html $(ER)/test.odd.html \`"; fi
 
 	$(BINDIR)/teitoodd $(FLAGS) test.odd $(AR)/test.processedodd
-	$(SAXON) $(AR)/test.processedodd ../odds/extract-isosch.xsl > $(AR)/test.isosch
+	$(SAXON) $(AR)/test.processedodd ../odds/extract-isosch.xsl lang=en > $(AR)/test.isosch
 	perl -i -p -e 's/This file generated [0-9T:Z-]+ by .extract-isosch.xsl./DELETED TIMESTAMP/' $(AR)/test.isosch
 	if [ $(DIFFNOW) -eq 1 ]; \
 		then diff  $(AR)/test.isosch $(ER)/test.isosch; \

--- a/Test/expected-results/test.isosch
+++ b/Test/expected-results/test.isosch
@@ -11,12 +11,9 @@
    <ns prefix="rna" uri="http://relaxng.org/ns/compatibility/annotations/1.0"/>
    <ns prefix="sch" uri="http://purl.oclc.org/dsdl/schematron"/>
    <ns prefix="sch1x" uri="http://www.ascc.net/xml/schematron"/>
-   <!-- ********************* -->
-   <!-- namespaces, implicit: -->
-   <!-- ********************* -->
-   <!-- ************ -->
-   <!-- constraints: -->
-   <!-- ************ -->
+   <!-- **************************************** -->
+   <!-- constraints in en, of which there are 59 -->
+   <!-- **************************************** -->
    <pattern id="schematron-constraint-test-att.cmc-generatedBy-CMC_generatedBy_within_post-1">
       <rule context="tei:*[@generatedBy]">
          <assert test="ancestor-or-self::tei:post">The @generatedBy attribute is for use within a &lt;post&gt; element.</assert>
@@ -40,11 +37,7 @@
    <pattern id="schematron-constraint-test-att.global.source-source-only_1_ODD_source-5">
       <rule context="tei:*[@source]">
          <let name="srcs" value="tokenize( normalize-space(@source),' ')"/>
-         <report test="( self::tei:classRef               | self::tei:dataRef               | self::tei:elementRef               | self::tei:macroRef               | self::tei:moduleRef               | self::tei:schemaSpec )               and               $srcs[2]">
-              When used on a schema description element (like
-              <value-of select="name(.)"/>), the @source attribute
-              should have only 1 value. (This one has <value-of select="count($srcs)"/>.)
-            </report>
+         <report test="( self::tei:classRef               | self::tei:dataRef               | self::tei:elementRef               | self::tei:macroRef               | self::tei:moduleRef               | self::tei:schemaSpec )               and               $srcs[2]"> When used on a schema description element (like <value-of select="name(.)"/>), the @source attribute should have only 1 value. (This one has <value-of select="count($srcs)"/>.)</report>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-att.measurement-att-measurement-unitRef-6">
@@ -64,46 +57,33 @@
    </pattern>
    <pattern id="schematron-constraint-test-att.spanning-spanTo-spanTo-points-to-following-9">
       <rule context="tei:*[@spanTo]">
-         <assert test="id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)]">
-The element indicated by @spanTo (<value-of select="@spanTo"/>) must follow the current element <name/>
+         <assert test="id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)]"> The element indicated by @spanTo (<value-of select="@spanTo"/>) must follow the current element <name/>
          </assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-att.styleDef-schemeVersion-schemeVersionRequiresScheme-10">
       <rule context="tei:*[@schemeVersion]">
-         <assert test="@scheme and not(@scheme = 'free')">
-              @schemeVersion can only be used if @scheme is specified.
-            </assert>
+         <assert test="@scheme and not(@scheme = 'free')"> @schemeVersion can only be used if @scheme is specified.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-att.calendarSystem-calendar-calendar_attr_on_empty_element-11">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-              systems or calendars to which the date represented by the content of this element belongs,
-              but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-p-abstractModel-structure-p-in-ab-or-p-12">
       <rule context="tei:p">
-         <report test="(ancestor::tei:ab or ancestor::tei:p) and                        not( ancestor::tei:floatingText                           | parent::tei:exemplum                           | parent::tei:item                           | parent::tei:note                           | parent::tei:q                           | parent::tei:quote                           | parent::tei:remarks                           | parent::tei:said                           | parent::tei:sp                           | parent::tei:stage                           | parent::tei:cell                           | parent::tei:figure )">
-          Abstract model violation: Paragraphs may not occur inside other paragraphs or ab elements.
-        </report>
+         <report test="(ancestor::tei:ab or ancestor::tei:p) and                        not( ancestor::tei:floatingText                           | parent::tei:exemplum                           | parent::tei:item                           | parent::tei:note                           | parent::tei:q                           | parent::tei:quote                           | parent::tei:remarks                           | parent::tei:said                           | parent::tei:sp                           | parent::tei:stage                           | parent::tei:cell                           | parent::tei:figure )"> Abstract model violation: Paragraphs may not occur inside other paragraphs or ab elements.</report>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-p-abstractModel-structure-p-in-l-or-lg-13">
       <rule context="tei:p">
-         <report test="( ancestor::tei:l  or  ancestor::tei:lg ) and                        not( ancestor::tei:floatingText                           | parent::tei:figure                           | parent::tei:note )">
-          Abstract model violation: Lines may not contain higher-level structural elements such as div, p, or ab, unless p is a child of figure or note, or is a descendant of floatingText.
-        </report>
+         <report test="( ancestor::tei:l  or  ancestor::tei:lg ) and                        not( ancestor::tei:floatingText                           | parent::tei:figure                           | parent::tei:note )"> Abstract model violation: Lines may not contain higher-level structural elements such as div, p, or ab, unless p is a child of figure or note, or is a descendant of floatingText.</report>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-desc-deprecationInfo-only-in-deprecated-14">
       <rule context="tei:desc[ @type eq 'deprecationInfo']">
-         <assert test="../@validUntil">Information about a
-        deprecation should only be present in a specification element
-        that is being deprecated: that is, only an element that has a
-        @validUntil attribute should have a child &lt;desc
-        type="deprecationInfo"&gt;.</assert>
+         <assert test="../@validUntil">Information about a deprecation should only be present in a specification element that is being deprecated: that is, only an element that has a @validUntil attribute should have a child &lt;desc type="deprecationInfo"&gt;.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-rt-target-rt-target-not-span-15">
@@ -123,9 +103,7 @@ The element indicated by @spanTo (<value-of select="@spanTo"/>) must follow the 
    </pattern>
    <pattern id="schematron-constraint-test-name-calendar-calendar-check-name-18">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-ptr-ptrAtts-19">
@@ -146,37 +124,27 @@ The element indicated by @spanTo (<value-of select="@spanTo"/>) must follow the 
    </pattern>
    <pattern id="schematron-constraint-test-author-calendar-calendar-check-author-22">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-editor-calendar-calendar-check-editor-23">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-resp-calendar-calendar-check-resp-24">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-title-calendar-calendar-check-title-25">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-meeting-calendar-calendar-check-meeting-26">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-relatedItem-targetorcontent1-27">
@@ -202,44 +170,32 @@ The element indicated by @spanTo (<value-of select="@spanTo"/>) must follow the 
    </pattern>
    <pattern id="schematron-constraint-test-sponsor-calendar-calendar-check-sponsor-31">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-funder-calendar-calendar-check-funder-32">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-principal-calendar-calendar-check-principal-33">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-idno-calendar-calendar-check-idno-34">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-licence-calendar-calendar-check-licence-35">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-quotation-quotationContents-36">
       <rule context="tei:quotation">
-         <report test="not( @marks )  and  not( tei:p )">
-          On <name/>, either the @marks attribute should be used, or a paragraph of description provided
-        </report>
+         <report test="not( @marks )  and  not( tei:p )"> On <name/>, either the @marks attribute should be used, or a paragraph of description provided</report>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-citeStructure-match-citestructure-outer-match-37">
@@ -254,52 +210,37 @@ The element indicated by @spanTo (<value-of select="@spanTo"/>) must follow the 
    </pattern>
    <pattern id="schematron-constraint-test-unitDecl-calendar-calendar-check-unitDecl-39">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-unitDef-calendar-calendar-check-unitDef-40">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-conversion-calendar-calendar-check-conversion-41">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-application-calendar-calendar-check-application-42">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-creation-calendar-calendar-check-creation-43">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-change-calendar-calendar-check-change-44">
       <rule context="tei:*[@calendar]">
-         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more
-                        systems or calendars to which the date represented by the content of this element belongs,
-                        but this <name/> element has no textual content.</assert>
+         <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-facsimile-no_facsimile_text_nodes-45">
       <rule context="tei:facsimile//tei:line | tei:facsimile//tei:zone">
-         <report test="child::text()[ normalize-space(.) ne '']">
-          A facsimile element represents a text with images, thus
-          transcribed text should not be present within it.
-        </report>
+         <report test="child::text()[ normalize-space(.) ne '']"> A facsimile element represents a text with images, thus transcribed text should not be present within it.</report>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-path-pathmustnotbeclosed-46">
@@ -311,9 +252,7 @@ The element indicated by @spanTo (<value-of select="@spanTo"/>) must follow the 
          <let name="firstY" value="xs:float( substring-after( $firstPair, ',') )"/>
          <let name="lastX" value="xs:float( substring-before( $lastPair, ',') )"/>
          <let name="lastY" value="xs:float( substring-after( $lastPair, ',') )"/>
-         <report test="$firstX eq $lastX and $firstY eq $lastY">The first and
-          last elements of this path are the same. To specify a closed polygon, use
-          the zone element rather than the path element. </report>
+         <report test="$firstX eq $lastX and $firstY eq $lastY">The first and last elements of this path are the same. To specify a closed polygon, use the zone element rather than the path element.</report>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-addSpan-addSpan-requires-spanTo-47">
@@ -339,49 +278,40 @@ The element indicated by @spanTo (<value-of select="@spanTo"/>) must follow the 
    </pattern>
    <pattern id="schematron-constraint-test-div-abstractModel-structure-div-in-l-or-lg-57">
       <rule context="tei:div">
-         <report test="(ancestor::tei:l or ancestor::tei:lg) and not(ancestor::tei:floatingText)">
-          Abstract model violation: Lines may not contain higher-level structural elements such as div, unless div is a descendant of floatingText.
-        </report>
+         <report test="(ancestor::tei:l or ancestor::tei:lg) and not(ancestor::tei:floatingText)"> Abstract model violation: Lines may not contain higher-level structural elements such as div, unless div is a descendant of floatingText.</report>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-div-abstractModel-structure-div-in-ab-or-p-58">
       <rule context="tei:div">
-         <report test="(ancestor::tei:p or ancestor::tei:ab) and not(ancestor::tei:floatingText)">
-          Abstract model violation: p and ab may not contain higher-level structural elements such as div, unless div is a descendant of floatingText.
-        </report>
+         <report test="(ancestor::tei:p or ancestor::tei:ab) and not(ancestor::tei:floatingText)"> Abstract model violation: p and ab may not contain higher-level structural elements such as div, unless div is a descendant of floatingText.</report>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-link-linkTargets3-59">
       <rule context="tei:link">
-         <assert test="contains(normalize-space(@target),' ')">You must supply at least two values for @target or  on <name/>
+         <assert test="contains(normalize-space(@target),' ')">You must supply at least two values for @target or on <name/>
          </assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-ab-abstractModel-structure-ab-in-l-or-lg-60">
       <rule context="tei:ab">
-         <report test="(ancestor::tei:l or ancestor::tei:lg) and not( ancestor::tei:floatingText |parent::tei:figure |parent::tei:note )">
-          Abstract model violation: Lines may not contain higher-level divisions such as p or ab, unless ab is a child of figure or note, or is a descendant of floatingText.
-        </report>
+         <report test="(ancestor::tei:l or ancestor::tei:lg) and not( ancestor::tei:floatingText |parent::tei:figure |parent::tei:note )"> Abstract model violation: Lines may not contain higher-level divisions such as p or ab, unless ab is a child of figure or note, or is a descendant of floatingText.</report>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-join-joinTargets3-61">
       <rule context="tei:join">
-         <assert test="contains( normalize-space( @target ),' ')">
-          You must supply at least two values for @target on <name/>
+         <assert test="contains( normalize-space( @target ),' ')"> You must supply at least two values for @target on <name/>
          </assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-test-standOff-nested_standOff_should_be_typed-62">
       <rule context="tei:standOff">
-         <assert test="@type or not(ancestor::tei:standOff)">This
-        <name/> element must have a @type attribute, since it is
-        nested inside a <name/>
+         <assert test="@type or not(ancestor::tei:standOff)">This <name/> element must have a @type attribute, since it is nested inside a <name/>
          </assert>
       </rule>
    </pattern>
-   <!-- *********** -->
-   <!-- deprecated: -->
-   <!-- *********** -->
+   <!-- ****************** -->
+   <!-- deprecation tests: -->
+   <!-- ****************** -->
    <pattern>
       <rule context="tei:name">
          <report test="@calendar" role="nonfatal">WARNING: use of deprecated attribute — @calendar of the name element will be removed from the TEI on 2024-11-11.

--- a/Test2/build_odd.xml
+++ b/Test2/build_odd.xml
@@ -164,10 +164,12 @@
   <target name="extractSchematronFromOdd">
     <description>
       TARGET extractSchematronFromOdd
-      This target uses Stylesheets/odds/extract-isosch.xsl to
-      extract the Schematron embedded in an ODD file. It takes
-      a single parameter inFile, the name of the ODD file, and creates
-      a single Schematron file, outputFiles/[oddFileNameWithoutExtension]FromOdd.sch.
+      This target uses Stylesheets/odds/extract-isosch.xsl to extract
+      the Schematron embedded in an ODD file. It takes two parameters:
+      inFile, the name of the ODD file, and lang, the natural language
+      of the constraints from which to extract Schematron. It creates
+      a single Schematron file:
+      outputFiles/[oddFileNameWithoutExtension]FromOdd.sch.
     </description>
     <basename file="${inFile}" property="plainFileName" suffix=".odd"/>
     <property name="schFromOddFile" value="${outputDir}/${plainFileName}FromOdd.sch"/>
@@ -178,6 +180,7 @@
       <arg value="-o:${schFromOddFile}"/>
       <arg value="--suppressXsltNamespaceCheck:on"/>
       <arg value="-versionmsg:off"/>
+      <arg value="lang=en"/>
     </java>
     
   </target>

--- a/bin/transformtei
+++ b/bin/transformtei
@@ -248,7 +248,7 @@ case $format in
           ;;
 esac
 
-echo Convert ${indir}/${infilename} to ${outdir}/${outfilename} \($from to $to\) using profile $profile $debug $fileperpage $splitLevel $viewportwidth $viewportheight 
+echo Convert ${indir}/${infilename} to ${outdir}/${outfilename} \($from to $to\) using profile $profile $debug $fileperpage $splitLevel $viewportwidth $viewportheight lang=$lang
 ant $antflag -f "$APPHOME/$format/build-$direction.xml" \
         -lib "${SAXONJAR}" $debug \
     $fileperpage $cssFile $splitLevel $viewportwidth $viewportheight $summaryDoc $mediaoverlay $nocompress \

--- a/debian-tei-xsl/debian/changelog
+++ b/debian-tei-xsl/debian/changelog
@@ -1,3 +1,9 @@
+tei-xsl (7.58.0a) natty; urgency=low
+
+  * new release from upstream
+
+ -- TEI                           <editors@www.tei-c.org>  Thu, 24 Oct 2024 20:09:41 -0400
+
 tei-xsl (7.57.0a) natty; urgency=low
 
   * new release from upstream

--- a/schematron/build-to.xml
+++ b/schematron/build-to.xml
@@ -28,8 +28,13 @@
     <odd2odd in="${inputFile}" out="${inputFile}.processedodd"/>
     <xslt processor="trax" force="yes" style="${profiledir}/${profile}/schematron/to.xsl" in="${inputFile}.processedodd" out="${outputFile}">
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+      <param name="lang" expression="${lang}" if="lang"/>
     </xslt>
-    <delete file="${inputFile}.processedodd"/>
+    <!-- Temporarily removed in order to make it easier to debug
+	 sydb_702_schematron_extraction branch:
+      <delete file="${inputFile}.processedodd"/>
+         Should probably be re-instated before that branch is merged
+	 into dev. -->
   </target>
 
   <target name="notodd" unless="processODD">


### PR DESCRIPTION
An attempt to address #702. Note that there are a **lot** of changes, here. So I think the best way to review this PR is not to try to read all the actual code changes, but rather to whip up a bunch of ODD files that

- do and do not have a `<constraintDecl>`[1]
- when there is a `<constraintDecl>`, have only `<sch:ns>` children of it, or have both `<sch:ns>` children and something else; maybe try it empty, too
- have a namespace or two declared on `<schemaSpec>`, `<elementSpec>`, and `<attDef>` via `@ns`
- have `<constraint>`s in various languages (either by having `@xml:lang` or by being inside a `<constraintSpec>` or `<div>` or whatever that itself has an `@xml:lang`)

And then convert the ODD file to Schematron with odds/extract-isoschematron.xsl using various values on the $lang parameter, and check that the output looks reasonable. Note that the `teitoschematron --odd --lang=ja /path/to/test/file.odd` command in this branch has been modified to leave the /path/to/test/file.odd.processedodd file lying around, so after you have generated it once you can then (relatively quickly) run just the extract-isoschematron.xsl with various other values for $lang.

As for testing this branch with the `make test` and `make test2` commands, I have updated the expected results to match this new version. The Test2/ tests all pass, but the Test/ test suite dies for inability to generate actual-results/oddbyexample.xsd. I do not think that has anything to do with the changes here, which is confirmed by the fact that the exact same error occurs in the "released" branch.

**Notes**
[1] If you want schema assistance generating a `<constraintDecl>`, or just want a valid ODD once you have created one, use schemas generated from the TEI branch "sydb_issue_230_constraintDecl".