### PR TITLE
Added normalize-space to gloss value

### DIFF
--- a/Test/expected-results/test.rng
+++ b/Test/expected-results/test.rng
@@ -4413,8 +4413,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
 Suggested values include: 1] deprecationInfo (deprecation information)</a:documentation>
           <choice>
             <value>deprecationInfo</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deprecation
-          information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.</a:documentation>
             <data type="token">
               <param name="pattern">[^\p{C}\p{Z}]+</param>
             </data>
@@ -8650,8 +8649,7 @@ Suggested values include: 1] initial; 2] final</a:documentation>
   </define>
   <define name="triangle">
     <element name="triangle">
-      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(underspecified embedding tree, so called because of its
-  characteristic shape when drawn) provides for an underspecified <code xmlns="http://www.w3.org/1999/xhtml" xmlns:rng="http://relaxng.org/ns/structure/1.0">&lt;eTree&gt;</code>, that is, an <code xmlns="http://www.w3.org/1999/xhtml" xmlns:rng="http://relaxng.org/ns/structure/1.0">&lt;eTree&gt;</code> with information left out. [20.3. Another Tree Notation]</a:documentation>
+      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(underspecified embedding tree, so called because of its characteristic shape when drawn) provides for an underspecified <code xmlns="http://www.w3.org/1999/xhtml" xmlns:rng="http://relaxng.org/ns/structure/1.0">&lt;eTree&gt;</code>, that is, an <code xmlns="http://www.w3.org/1999/xhtml" xmlns:rng="http://relaxng.org/ns/structure/1.0">&lt;eTree&gt;</code> with information left out. [20.3. Another Tree Notation]</a:documentation>
       <group>
         <optional>
           <ref name="label"/>

--- a/Test/expected-results/test15.odd.rnc
+++ b/Test/expected-results/test15.odd.rnc
@@ -2473,8 +2473,7 @@ desc =
     ## Suggested values include: 1] deprecationInfo (deprecation information)
     attribute type {
       
-      ## (deprecation
-      ##           information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
+      ## (deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
       "deprecationInfo"
       | xsd:token { pattern = "[^\p{C}\p{Z}]+" }
     }?,

--- a/Test/expected-results/test21.odd.rnc
+++ b/Test/expected-results/test21.odd.rnc
@@ -2839,8 +2839,7 @@ desc =
     ## Suggested values include: 1] deprecationInfo (deprecation information)
     attribute type {
       
-      ## (deprecation
-      ##           information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
+      ## (deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
       "deprecationInfo"
       | xsd:token { pattern = "[^\p{C}\p{Z}]+" }
     }?,
@@ -6336,8 +6335,7 @@ geoDecl =
       ## (Système Géodésique Mondial) couple de nombres destinés à être interprétés comme la latitude suivie de la longitude selon le Système Géodésique Mondial.
       "WGS84"
       | 
-        ## (Système de Référence du Réseau Militaire,
-        ##             (MGRS).) les valeurs fournies sont des codes objet d'entités geospatiales, fondées sur les coordonnées de la grille de projection transversale universelle de Mercator, (UTM).
+        ## (Système de Référence du Réseau Militaire, (MGRS).) les valeurs fournies sont des codes objet d'entités geospatiales, fondées sur les coordonnées de la grille de projection transversale universelle de Mercator, (UTM).
         "MGRS"
       | 
         ## (Système de coordonnées de Grande-Bretagne (OSGB) ) la valeur fournie est à interpréter selon le système "British national grid reference".
@@ -9427,15 +9425,13 @@ titlePart =
         ## (sous-titre de l’ouvrage.) sous-titre de l'oeuvre.
         "sub"
       | 
-        ## (titre alternatif de
-        ##                         l’ouvrage.) autre titre de l'oeuvre.
+        ## (titre alternatif de l’ouvrage.) autre titre de l'oeuvre.
         "alt"
       | 
         ## (short) forme abrégée du titre.
         "short"
       | 
-        ## (description paraphrastique de
-        ##                             l’ouvrage.) texte qui paraphrase l'oeuvre.
+        ## (description paraphrastique de l’ouvrage.) texte qui paraphrase l'oeuvre.
         "desc"
       | xsd:token { pattern = "[^\p{C}\p{Z}]+" }
     }?,

--- a/Test/expected-results/test30.rnc
+++ b/Test/expected-results/test30.rnc
@@ -2731,8 +2731,7 @@ Tdesc =
     ## Suggested values include: 1] deprecationInfo (deprecation information)
     attribute type {
       
-      ## (deprecation
-      ##           information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
+      ## (deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
       "deprecationInfo"
       | xsd:token { pattern = "[^\p{C}\p{Z}]+" }
     }?,

--- a/Test/expected-results/test33.rnc
+++ b/Test/expected-results/test33.rnc
@@ -2456,8 +2456,7 @@ tei_desc =
     ## Suggested values include: 1] deprecationInfo (deprecation information)
     attribute type {
       
-      ## (deprecation
-      ##           information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
+      ## (deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
       "deprecationInfo"
       | xsd:token { pattern = "[^\p{C}\p{Z}]+" }
     }?,

--- a/Test/expected-results/test34.combined.json
+++ b/Test/expected-results/test34.combined.json
@@ -3231,9 +3231,9 @@
                 { "ident" : "deprecationInfo",
                   "desc" : 
                   [ "<desc xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2018-09-14\" xml:lang=\"en\">This element\n          describes why or how its parent element is being deprecated,\n          typically including recommendations for alternate\n          encoding.<\/desc>" ],
-                  "shortDesc" : "(deprecation\n          information) This element\n          describes why or how its parent element is being deprecated,\n          typically including recommendations for alternate\n          encoding.",
+                  "shortDesc" : "(deprecation information) This element\n          describes why or how its parent element is being deprecated,\n          typically including recommendations for alternate\n          encoding.",
                   "gloss" : 
-                  [ "<gloss xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2018-09-14\" xml:lang=\"en\">deprecation\n          information<\/gloss>" ],
+                  [ "<gloss xmlns=\"http:\/\/www.tei-c.org\/ns\/1.0\" versionDate=\"2018-09-14\" xml:lang=\"en\">deprecation information<\/gloss>" ],
                   "altIdent" : 
                   [  ] } ] } } ],
         "content" : 

--- a/Test/expected-results/test34.rnc
+++ b/Test/expected-results/test34.rnc
@@ -2461,8 +2461,7 @@ tei_desc =
     ## Suggested values include: 1] deprecationInfo (deprecation information)
     attribute type {
       
-      ## (deprecation
-      ##           information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
+      ## (deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
       "deprecationInfo"
       | xsd:token { pattern = "[^\p{C}\p{Z}]+" }
     }?,

--- a/Test/expected-results/test35.rnc
+++ b/Test/expected-results/test35.rnc
@@ -2456,8 +2456,7 @@ tei_desc =
     ## Suggested values include: 1] deprecationInfo (deprecation information)
     attribute type {
       
-      ## (deprecation
-      ##           information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
+      ## (deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.
       "deprecationInfo"
       | xsd:token { pattern = "[^\p{C}\p{Z}]+" }
     }?,

--- a/Test/expected-results/testdrama.compiled.xml
+++ b/Test/expected-results/testdrama.compiled.xml
@@ -8748,8 +8748,7 @@ Ce ne seroyt que bon que nous rendissiez noz cloches...</egXML>
     <attDef ident="type" mode="change">
       <valList type="semi">
         <valItem ident="deprecationInfo">
-          <gloss versionDate="2018-09-14" xml:lang="en">deprecation
-          information</gloss>
+          <gloss versionDate="2018-09-14" xml:lang="en">deprecation information</gloss>
           <desc versionDate="2018-09-14" xml:lang="en">This element
           describes why or how its parent element is being deprecated,
           typically including recommendations for alternate

--- a/Test2/expected-results/testAttValQuant.rng
+++ b/Test2/expected-results/testAttValQuant.rng
@@ -3834,8 +3834,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
 Suggested values include: 1] deprecationInfo (deprecation information)</a:documentation>
                <choice>
                   <value>deprecationInfo</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deprecation
-          information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.</a:documentation>
                   <data type="token">
                      <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>

--- a/Test2/expected-results/testNonTeiOdd1.rng
+++ b/Test2/expected-results/testNonTeiOdd1.rng
@@ -183,8 +183,7 @@
          <ref name="att.identifiable.attributes"/>
          <optional>
             <attribute name="class">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The class attribute provides styles through rules in the CSS
-                stylesheet. ) </a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The class attribute provides styles through rules in the CSS stylesheet.) </a:documentation>
                <list>
                   <oneOrMore>
                      <choice>
@@ -212,20 +211,17 @@
          </attribute>
          <optional>
             <attribute name="data-lg-version">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(path to a larger version of the image to show as a popup (usually a
-                relative path)) </a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(path to a larger version of the image to show as a popup (usually a relative path)) </a:documentation>
             </attribute>
          </optional>
          <optional>
             <attribute name="alt">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of the image for visually-impaired users. If not
-                supplied, then figcaption will be used instead.) </a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of the image for visually-impaired users. If not supplied, then figcaption will be used instead.) </a:documentation>
             </attribute>
          </optional>
          <optional>
             <attribute name="title">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of the image which will pop up on mouseover. If not
-                supplied, then figcaption will be used instead.) </a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of the image which will pop up on mouseover. If not supplied, then figcaption will be used instead.) </a:documentation>
             </attribute>
          </optional>
          <empty/>
@@ -253,8 +249,7 @@
          </attribute>
          <optional>
             <attribute name="title">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(explanation of what is being linked to. Will pop up when mousing over
-                the link.) </a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(explanation of what is being linked to. Will pop up when mousing over the link.) </a:documentation>
             </attribute>
          </optional>
          <empty/>
@@ -272,19 +267,16 @@
          <ref name="att.classable.attribute.style"/>
          <ref name="att.identifiable.attributes"/>
          <attribute name="class">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The class attribute provides styles through rules in the CSS
-                stylesheet. ) </a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The class attribute provides styles through rules in the CSS stylesheet.) </a:documentation>
             <list>
                <oneOrMore>
                   <choice>
                      <value>leftFloat</value>
-                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Float this figure to the left and flow the text around
-                    it.) </a:documentation>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Float this figure to the left and flow the text around it.) </a:documentation>
                      <value>center</value>
                      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Centre this figure and do not float text around it.) </a:documentation>
                      <value>rightFloat</value>
-                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Float this figure to the right and flow the text around
-                    it.) </a:documentation>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Float this figure to the right and flow the text around it.) </a:documentation>
                   </choice>
                </oneOrMore>
             </list>
@@ -392,8 +384,7 @@
    <define name="att.classable.attribute.class">
       <optional>
          <attribute name="class">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The class attribute provides styles through rules in the CSS
-                stylesheet. ) </a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The class attribute provides styles through rules in the CSS stylesheet.) </a:documentation>
             <list>
                <rng:empty xmlns:rng="http://relaxng.org/ns/structure/1.0"/>
             </list>
@@ -403,9 +394,7 @@
    <define name="att.classable.attribute.style">
       <optional>
          <attribute name="style">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The style attribute provides one-off style options for specific and
-                unusual cases. Do not use this unless you know that the element you're
-                styling is unlike any other element on the site.) </a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The style attribute provides one-off style options for specific and unusual cases. Do not use this unless you know that the element you're styling is unlike any other element on the site.) </a:documentation>
          </attribute>
       </optional>
    </define>

--- a/Test2/expected-results/testPure1.rng
+++ b/Test2/expected-results/testPure1.rng
@@ -4579,8 +4579,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
 Suggested values include: 1] deprecationInfo (deprecation information)</a:documentation>
                <choice>
                   <value>deprecationInfo</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deprecation
-          information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deprecation information) This element describes why or how its parent element is being deprecated, typically including recommendations for alternate encoding.</a:documentation>
                   <data type="token">
                      <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>

--- a/Test2/expected-results/testSpecificationDescription1.rng
+++ b/Test2/expected-results/testSpecificationDescription1.rng
@@ -7754,8 +7754,7 @@ Suggested values include: 1] initial; 2] final</a:documentation>
    </define>
    <define name="triangle">
       <element name="triangle">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(underspecified embedding tree, so called because of its
-  characteristic shape when drawn) provides for an underspecified eTree, that is, an eTree with information left out. [19.3. Another Tree Notation]</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(underspecified embedding tree, so called because of its characteristic shape when drawn) provides for an underspecified eTree, that is, an eTree with information left out. [19.3. Another Tree Notation]</a:documentation>
          <group>
       
             <optional>

--- a/odds/odd2lite.xsl
+++ b/odds/odd2lite.xsl
@@ -586,7 +586,7 @@ of this software, even if advised of the possibility of such damage.
         </xsl:if>
         
          <xsl:copy-of select="@xml:lang"/>
-         <xsl:value-of select="."/>
+         <xsl:value-of select="normalize-space(.)"/>
       </seg>
   </xsl:template>
 

--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -2470,7 +2470,7 @@ of this software, even if advised of the possibility of such damage.
   </xsl:template>
 
   <xsl:template match="tei:gloss" mode="inLanguage">
-    <xsl:value-of select="."/>
+    <xsl:value-of select="normalize-space(.)"/>
   </xsl:template>
   <xsl:template match="tei:desc" mode="inLanguage">
     <xsl:apply-templates/>

--- a/source/p5subset.xml
+++ b/source/p5subset.xml
@@ -16810,8 +16810,7 @@ Ce ne seroyt que bon que nous rendissiez noz cloches...</egXML>
     <attDef ident="type" mode="change">
       <valList type="semi">
         <valItem ident="deprecationInfo">
-          <gloss versionDate="2018-09-14" xml:lang="en">deprecation
-          information</gloss>
+          <gloss versionDate="2018-09-14" xml:lang="en">deprecation information</gloss>
           <desc versionDate="2018-09-14" xml:lang="en">This element
           describes why or how its parent element is being deprecated,
           typically including recommendations for alternate


### PR DESCRIPTION
# Dealing with #717 

## What I did:
Found the place where the content of gloss was created and normalized the whitespace

## How I tested:
- Add whitespace at the beginning or ending of a gloss in /TEI/P5/Source/Specs
- Build the guidelines (using this branch of the stylesheets) and see if the whitespaces are normalized

## Example test:
Change  /TEI/P5/Source/Specs/ab.xml (line 5) to:
`<gloss versionDate="2005-01-14" xml:lang="en"> anonymous block </gloss>`

Old output (with dev branch):

> \<ab\> ( anonymous block ) contains any ...


New output from this branch:

> \<ab\> (anonymous block) contains any ...