### PR TITLE
process new `<constraintDecl>` element when generating RELAX NG

### DIFF
--- a/odds/odd2relax.xsl
+++ b/odds/odd2relax.xsl
@@ -128,7 +128,10 @@ of this software, even if advised of the possibility of such damage.
           <xsl:call-template name="schemaSpecBody"/>
         </xsl:otherwise>
       </xsl:choose>
-      <xsl:apply-templates select="tei:constraintSpec"/>
+      <xsl:apply-templates
+	  select=" tei:constraintSpec
+		  |tei:constraintDecl[ @scheme eq 'schematron']
+		  |ancestor::tei:TEI/tei:teiHeader//tei:constraintDecl[ @scheme eq 'schematron']"/>
     </xsl:variable>
     <xsl:call-template name="generateOutput">
       <xsl:with-param name="method">xml</xsl:with-param>

--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -2482,10 +2482,14 @@ of this software, even if advised of the possibility of such damage.
     </xsl:for-each>
   </xsl:template>
 
-  <xsl:template match="tei:constrainSpec|tei:constraint">
+  <xsl:template match="tei:constraintSpec|tei:constraint">
     <xsl:apply-templates/>
   </xsl:template>
 
+  <xsl:template match="tei:constraintDecl[ @scheme eq 'schematron']">
+    <xsl:apply-templates select="sch:*" mode="justcopy"/>
+  </xsl:template>
+  
   <xsl:template match="sch:*">
     <xsl:call-template name="processSchematron"/>
   </xsl:template>


### PR DESCRIPTION
Stylesheets group figured out how to process constraintDecl when processing the Schematron that goes into RELAX NG output.

This is currently a DRAFT PR because there are no tests. As soon as tests (in Test2/) exist the DRAFT can be removed. As soon as it _passes_ those tests it can be merged. (Note that @joeytakeda has volunteered to add the tests to this branch.)

This address issue #697.
