### PR TITLE
actually process `<constraintDecl>`

### DIFF
--- a/Test/expected-results/test.isosch
+++ b/Test/expected-results/test.isosch
@@ -12,152 +12,152 @@
    <ns prefix="sch" uri="http://purl.oclc.org/dsdl/schematron"/>
    <ns prefix="sch1x" uri="http://www.ascc.net/xml/schematron"/>
    <!-- ******************************************************* -->
-   <!-- constraints in en, und, mul, zxx, of which there are 42 -->
+   <!-- constraints in en, und, mul, zxx, of which there are 39 -->
    <!-- ******************************************************* -->
-   <pattern id="schematron-constraint-test-att.cmc-generatedBy-CMC_generatedBy_within_post-1">
+   <pattern id="schematron-constraint-CMC_generatedBy_within_post-1">
       <rule context="tei:*[@generatedBy]">
          <assert test="ancestor-or-self::tei:post">The @generatedBy attribute is for use within a &lt;post&gt; element.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.datable.w3c-att-datable-w3c-when-2">
+   <pattern id="schematron-constraint-att-datable-w3c-when-2">
       <rule context="tei:*[@when]">
          <report test="@notBefore|@notAfter|@from|@to" role="nonfatal">The @when attribute cannot be used with any other att.datable.w3c attributes.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.datable.w3c-att-datable-w3c-from-3">
+   <pattern id="schematron-constraint-att-datable-w3c-from-3">
       <rule context="tei:*[@from]">
          <report test="@notBefore" role="nonfatal">The @from and @notBefore attributes cannot be used together.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.datable.w3c-att-datable-w3c-to-4">
+   <pattern id="schematron-constraint-att-datable-w3c-to-4">
       <rule context="tei:*[@to]">
          <report test="@notAfter" role="nonfatal">The @to and @notAfter attributes cannot be used together.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.global.source-source-only_1_ODD_source-5">
+   <pattern id="schematron-constraint-only_1_ODD_source-5">
       <rule context="tei:*[@source]">
          <let name="srcs" value="tokenize( normalize-space(@source),' ')"/>
          <report test="(   self::tei:classRef                                 | self::tei:dataRef                                 | self::tei:elementRef                                 | self::tei:macroRef                                 | self::tei:moduleRef                                 | self::tei:schemaSpec )                                   and                                   $srcs[2]"> When used on a schema description element (like <value-of select="name(.)"/>), the @source attribute should have only 1 value. (This one has <value-of select="count($srcs)"/>.)</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.measurement-att-measurement-unitRef-6">
+   <pattern id="schematron-constraint-att-measurement-unitRef-6">
       <rule context="tei:*[@unitRef]">
          <report test="@unit" role="info">The @unit attribute may be unnecessary when @unitRef is present.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.typed-subtypeTyped-7">
+   <pattern id="schematron-constraint-subtypeTyped-7">
       <rule context="tei:*[@subtype]">
          <assert test="@type">The <name/> element should not be categorized in detail with @subtype unless also categorized in general with @type</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.pointing-targetLang-targetLang-8">
+   <pattern id="schematron-constraint-targetLang-8">
       <rule context="tei:*[not(self::tei:schemaSpec)][@targetLang]">
          <assert test="@target">@targetLang should only be used on <name/> if @target is specified.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.spanning-spanTo-spanTo-points-to-following-9">
+   <pattern id="schematron-constraint-spanTo-points-to-following-9">
       <rule context="tei:*[@spanTo]">
          <assert test="id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)]"> The element indicated by @spanTo (<value-of select="@spanTo"/>) must follow the current element <name/>
          </assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.styleDef-schemeVersion-schemeVersionRequiresScheme-10">
+   <pattern id="schematron-constraint-schemeVersionRequiresScheme-10">
       <rule context="tei:*[@schemeVersion]">
          <assert test="@scheme and not(@scheme = 'free')"> @schemeVersion can only be used if @scheme is specified.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-att.calendarSystem-calendar-calendar_attr_on_empty_element-11">
+   <pattern id="schematron-constraint-calendar_attr_on_empty_element-11">
       <rule context="tei:*[@calendar]">
          <assert test="string-length( normalize-space(.) ) gt 0"> @calendar indicates one or more systems or calendars to which the date represented by the content of this element belongs, but this <name/> element has no textual content.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-p-abstractModel-structure-p-in-ab-or-p-12">
+   <pattern id="schematron-constraint-abstractModel-structure-p-in-ab-or-p-12">
       <rule context="tei:p">
          <report test="(ancestor::tei:ab or ancestor::tei:p) and                        not( ancestor::tei:floatingText                           | parent::tei:exemplum                           | parent::tei:item                           | parent::tei:note                           | parent::tei:q                           | parent::tei:quote                           | parent::tei:remarks                           | parent::tei:said                           | parent::tei:sp                           | parent::tei:stage                           | parent::tei:cell                           | parent::tei:figure )"> Abstract model violation: Paragraphs may not occur inside other paragraphs or ab elements.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-p-abstractModel-structure-p-in-l-or-lg-13">
+   <pattern id="schematron-constraint-abstractModel-structure-p-in-l-or-lg-13">
       <rule context="tei:p">
          <report test="( ancestor::tei:l  or  ancestor::tei:lg ) and                        not( ancestor::tei:floatingText                           | parent::tei:figure                           | parent::tei:note )"> Abstract model violation: Lines may not contain higher-level structural elements such as div, p, or ab, unless p is a child of figure or note, or is a descendant of floatingText.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-desc-deprecationInfo-only-in-deprecated-14">
+   <pattern id="schematron-constraint-deprecationInfo-only-in-deprecated-14">
       <rule context="tei:desc[ @type eq 'deprecationInfo']">
          <assert test="../@validUntil">Information about a deprecation should only be present in a specification element that is being deprecated: that is, only an element that has a @validUntil attribute should have a child &lt;desc type="deprecationInfo"&gt;.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-rt-target-rt-target-not-span-15">
+   <pattern id="schematron-constraint-rt-target-not-span-15">
       <rule context="tei:rt/@target">
          <report test="../@from | ../@to">When target= is present, neither from= nor to= should be.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-rt-from-rt-from-16">
+   <pattern id="schematron-constraint-rt-from-16">
       <rule context="tei:rt/@from">
          <assert test="../@to">When from= is present, the to= attribute of <name/> is required.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-rt-to-rt-to-17">
+   <pattern id="schematron-constraint-rt-to-17">
       <rule context="tei:rt/@to">
          <assert test="../@from">When to= is present, the from= attribute of <name/> is required.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-ptr-ptrAtts-18">
+   <pattern id="schematron-constraint-ptrAtts-18">
       <rule context="tei:ptr">
          <report test="@target and @cRef">Only one of the attributes @target and @cRef may be supplied on <name/>.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-ref-refAtts-19">
+   <pattern id="schematron-constraint-refAtts-19">
       <rule context="tei:ref">
          <report test="@target and @cRef">Only one of the attributes @target and @cRef may be supplied on <name/>.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-list-gloss-list-must-have-labels-20">
+   <pattern id="schematron-constraint-gloss-list-must-have-labels-20">
       <rule context="tei:list[@type='gloss']">
          <assert test="tei:label">The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-relatedItem-targetorcontent1-21">
+   <pattern id="schematron-constraint-targetorcontent1-21">
       <rule context="tei:relatedItem">
          <report test="@target and count( child::* ) &gt; 0">If the @target attribute on <name/> is used, the relatedItem element must be empty</report>
          <assert test="@target or child::*">A relatedItem element should have either a @target attribute or a child element to indicate the related bibliographic item</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-l-abstractModel-structure-l-in-l-22">
+   <pattern id="schematron-constraint-abstractModel-structure-l-in-l-22">
       <rule context="tei:l">
          <report test="ancestor::tei:l[not(.//tei:note//tei:l[. = current()])]">Abstract model violation: Lines may not contain lines or lg elements.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-lg-atleast1oflggapl-23">
+   <pattern id="schematron-constraint-atleast1oflggapl-23">
       <rule context="tei:lg">
          <assert test="count(descendant::tei:lg|descendant::tei:l|descendant::tei:gap) &gt; 0">An lg element must contain at least one child l, lg, or gap element.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-lg-abstractModel-structure-lg-in-l-24">
+   <pattern id="schematron-constraint-abstractModel-structure-lg-in-l-24">
       <rule context="tei:lg">
          <report test="ancestor::tei:l[not(.//tei:note//tei:lg[. = current()])]">Abstract model violation: Lines may not contain line groups.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-quotation-quotationContents-25">
+   <pattern id="schematron-constraint-quotationContents-25">
       <rule context="tei:quotation">
          <report test="not( @marks )  and  not( tei:p )"> On <name/>, either the @marks attribute should be used, or a paragraph of description provided</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-citeStructure-match-citestructure-outer-match-26">
+   <pattern id="schematron-constraint-citestructure-outer-match-26">
       <rule context="tei:citeStructure[not(parent::tei:citeStructure)]">
          <assert test="starts-with(@match,'/')">An XPath in @match on the outer <name/> must start with '/'.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-citeStructure-match-citestructure-inner-match-27">
+   <pattern id="schematron-constraint-citestructure-inner-match-27">
       <rule context="tei:citeStructure[parent::tei:citeStructure]">
          <assert test="not(starts-with(@match,'/'))">An XPath in @match must not start with '/' except on the outer <name/>.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-facsimile-no_facsimile_text_nodes-28">
+   <pattern id="schematron-constraint-no_facsimile_text_nodes-28">
       <rule context="tei:facsimile//tei:line | tei:facsimile//tei:zone">
          <report test="child::text()[ normalize-space(.) ne '']"> A facsimile element represents a text with images, thus transcribed text should not be present within it.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-path-pathmustnotbeclosed-29">
+   <pattern id="schematron-constraint-pathmustnotbeclosed-29">
       <rule context="tei:path[@points]">
          <let name="firstPair" value="tokenize( normalize-space( @points ), ' ')[1]"/>
          <let name="lastPair"
@@ -169,55 +169,55 @@
          <report test="$firstX eq $lastX and $firstY eq $lastY">The first and last elements of this path are the same. To specify a closed polygon, use the zone element rather than the path element.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-addSpan-addSpan-requires-spanTo-30">
+   <pattern id="schematron-constraint-addSpan-requires-spanTo-30">
       <rule context="tei:addSpan">
          <assert test="@spanTo">The @spanTo attribute of <name/> is required.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-damageSpan-damageSpan-requires-spanTo-32">
+   <pattern id="schematron-constraint-damageSpan-requires-spanTo-32">
       <rule context="tei:damageSpan">
          <assert test="@spanTo">The @spanTo attribute of <name/> is required.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-delSpan-delSpan-requires-spanTo-34">
+   <pattern id="schematron-constraint-delSpan-requires-spanTo-34">
       <rule context="tei:delSpan">
          <assert test="@spanTo">The @spanTo attribute of <name/> is required.</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-subst-substContents1-36">
+   <pattern id="schematron-constraint-substContents1-36">
       <rule context="tei:subst">
          <assert test="child::tei:add and (child::tei:del or child::tei:surplus)">
             <name/> must have at least one child add and at least one child del or surplus</assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-div-abstractModel-structure-div-in-l-or-lg-40">
+   <pattern id="schematron-constraint-abstractModel-structure-div-in-l-or-lg-37">
       <rule context="tei:div">
          <report test="(ancestor::tei:l or ancestor::tei:lg) and not(ancestor::tei:floatingText)"> Abstract model violation: Lines may not contain higher-level structural elements such as div, unless div is a descendant of floatingText.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-div-abstractModel-structure-div-in-ab-or-p-41">
+   <pattern id="schematron-constraint-abstractModel-structure-div-in-ab-or-p-38">
       <rule context="tei:div">
          <report test="(ancestor::tei:p or ancestor::tei:ab) and not(ancestor::tei:floatingText)"> Abstract model violation: p and ab may not contain higher-level structural elements such as div, unless div is a descendant of floatingText.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-link-linkTargets3-42">
+   <pattern id="schematron-constraint-linkTargets3-39">
       <rule context="tei:link">
          <assert test="contains(normalize-space(@target),' ')">You must supply at least two values for @target or on <name/>
          </assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-ab-abstractModel-structure-ab-in-l-or-lg-43">
+   <pattern id="schematron-constraint-abstractModel-structure-ab-in-l-or-lg-40">
       <rule context="tei:ab">
          <report test="(ancestor::tei:l or ancestor::tei:lg) and not( ancestor::tei:floatingText |parent::tei:figure |parent::tei:note )"> Abstract model violation: Lines may not contain higher-level divisions such as p or ab, unless ab is a child of figure or note, or is a descendant of floatingText.</report>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-join-joinTargets3-44">
+   <pattern id="schematron-constraint-joinTargets3-41">
       <rule context="tei:join">
          <assert test="contains( normalize-space( @target ),' ')"> You must supply at least two values for @target on <name/>
          </assert>
       </rule>
    </pattern>
-   <pattern id="schematron-constraint-test-standOff-nested_standOff_should_be_typed-45">
+   <pattern id="schematron-constraint-nested_standOff_should_be_typed-42">
       <rule context="tei:standOff">
          <assert test="@type or not(ancestor::tei:standOff)">This <name/> element must have a @type attribute, since it is nested inside a <name/>
          </assert>

--- a/Test/expected-results/testdrama.compiled.xml
+++ b/Test/expected-results/testdrama.compiled.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:lang="en" n="testdrama">
-   <teiHeader>
-      <fileDesc>
+   <teiHeader><fileDesc>
          <titleStmt>
             <title>TEI with Drama</title>
             <author>Sebastian Rahtz</author>
@@ -11,8 +10,7 @@
          <sourceDesc>
             <p>authored from scratch</p>
          </sourceDesc>
-      </fileDesc>
-   </teiHeader>
+      </fileDesc></teiHeader>
 <text>
 <body>
     <schemaSpec xmlns:teix="http://www.tei-c.org/ns/Examples" ident="testdrama" start="TEI" defaultExceptions="http://www.tei-c.org/ns/1.0 teix:egXML" source="https://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml"><classSpec xmlns:xi="http://www.w3.org/2001/XInclude" module="tei" type="atts" xml:id="class-attr-anchoring" ident="att.anchoring">

--- a/Test2/expected-results/testPure1.rng
+++ b/Test2/expected-results/testPure1.rng
@@ -207,7 +207,7 @@
             </choice>
          </zeroOrMore>
       </element>
-      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="d9e50544-constraint">
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="d9e50543-constraint">
          <rule context="tei:ab">
             <report test="descendant::*[not(namespace-uri(.) =               ('http://www.loc.gov/mods/v3', 'http://www.tei-c.org/ns/1.0'))]">ab descendants must be in the
               namespaces
@@ -319,7 +319,7 @@
             </choice>
          </zeroOrMore>
       </element>
-      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="d9e50555-constraint">
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="d9e50554-constraint">
          <rule context="tei:ab">
             <report test="descendant::*[not(namespace-uri(.) =               ('http://www.w3.org/2000/svg', 'http://www.tei-c.org/ns/1.0'))]">ab descendants must be in the
               namespaces

--- a/Test2/expected-results/testPure1.rng
+++ b/Test2/expected-results/testPure1.rng
@@ -207,7 +207,7 @@
             </choice>
          </zeroOrMore>
       </element>
-      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="d9e50545-constraint">
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="d9e50544-constraint">
          <rule context="tei:ab">
             <report test="descendant::*[not(namespace-uri(.) =               ('http://www.loc.gov/mods/v3', 'http://www.tei-c.org/ns/1.0'))]">ab descendants must be in the
               namespaces
@@ -319,7 +319,7 @@
             </choice>
          </zeroOrMore>
       </element>
-      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="d9e50556-constraint">
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="d9e50555-constraint">
          <rule context="tei:ab">
             <report test="descendant::*[not(namespace-uri(.) =               ('http://www.w3.org/2000/svg', 'http://www.tei-c.org/ns/1.0'))]">ab descendants must be in the
               namespaces

--- a/odds/extract-isosch.xsl
+++ b/odds/extract-isosch.xsl
@@ -356,25 +356,19 @@ of this software, even if advised of the possibility of such damage.
           schema that does not perform the desired constraint tests properly.</xsl:message>
       </xsl:if>
 
-      <xsl:if test="$decorated//tei:constraintDecl[ @scheme eq 'schematron']/*[ not( self::sch:ns ) ]">
-        <xsl:call-template name="blockComment">
-          <xsl:with-param name="content" select="'declarations:'"/>
-        </xsl:call-template>
-        <xsl:apply-templates mode="copy"
-                             select="//tei:constraintDecl[ @scheme eq 'schematron']/*[not(self::sch:ns)]"/>
-      </xsl:if>
-      
-      <xsl:if test="key('CONSTRAINTs', $langs )">
+      <xsl:if test="key('CONSTRAINTs', $langs )[ not( self::sch:ns ) ]">
         <xsl:variable name="N"
-		      select="', of which there are '||count( key('CONSTRAINTs', $langs, $root )/self::constraint )"/>
+		      select="', of which there are '||count( key('CONSTRAINTs', $langs, $root )/*[ not( self::sch:ns ) ] )"/>
         <xsl:call-template name="blockComment">
           <xsl:with-param name="content" select="'constraints in '||string-join( $langs, ', ')||$N"/>
         </xsl:call-template>
       </xsl:if>
-      <xsl:for-each select="$root/key('CONSTRAINTs', $langs )">
+      <xsl:for-each select="$root/key('CONSTRAINTs', $langs )[ not( self::sch:ns ) ]">
         <xsl:variable name="patID" select="tei:makePatternID(.)"/>
+	<xsl:message select="'DEBUG: processing '||$patID"/>
         <xsl:choose>
           <xsl:when test="sch:pattern">
+	    <xsl:message select="'debug: a pattern child'"/>
             <!-- IF there is a child <pattern>, we just copy over all children, no tweaking -->
             <xsl:apply-templates select="node()">
               <!-- they all get handed $patID, but only the template for 'pattern' uses it -->
@@ -382,6 +376,7 @@ of this software, even if advised of the possibility of such damage.
             </xsl:apply-templates>
           </xsl:when>
           <xsl:when test="sch:rule">
+	    <xsl:message select="'debug: a rule child'"/>
             <!-- IF there is no <pattern>, but there is a <rule>, copy over all children -->
             <!-- into a newly created <pattern> wrapper -->
             <pattern id="{$patID}">
@@ -389,6 +384,7 @@ of this software, even if advised of the possibility of such damage.
             </pattern>
           </xsl:when>
           <xsl:when test="sch:assert | sch:report | sch:extends">
+	    <xsl:message select="'debug: some other child'"/>
             <!-- IF there is no <pattern> nor <rule> child, but there is a child that -->
             <!-- requires being wrapped in a rule, create both <rule> and <pattern> -->
             <!-- wrappers for them, making HERE the context.   NOTE: As of 2025-03-15 -->
@@ -402,6 +398,7 @@ of this software, even if advised of the possibility of such damage.
             </pattern>
           </xsl:when>
           <xsl:otherwise>
+	    <xsl:message select="'debug: OTHERWISE'"/>
             <!-- IF there is neither a <pattern> nor a <rule>, nor a child that would -->
             <!-- require being wrapped in those, just copy over whatever we have -->
             <xsl:apply-templates select="node()"/>
@@ -596,15 +593,28 @@ of this software, even if advised of the possibility of such damage.
   </d:doc>
   <xsl:function name="tei:makePatternID" as="xs:string">
     <xsl:param name="context"/>
-    <xsl:variable name="scheme" select="$context/ancestor-or-self::constraintSpec/@scheme"/>
+    <xsl:variable name="scheme" select="$context/ancestor-or-self::constraintSpec/@scheme|$context/ancestor-or-self::constraintDecl/@scheme"/>
     <xsl:for-each select="$context">
       <xsl:variable name="num">
         <xsl:number level="any"/>
       </xsl:variable>
+      <xsl:variable name="id">
+	<xsl:choose>
+	  <xsl:when test="ancestor-or-self::*[@ident]">
+	    <xsl:sequence select="ancestor-or-self::*[@ident][1]/@ident!translate( .,':','')"/>
+	  </xsl:when>
+	  <xsl:when test="ancestor-or-self::*[@xml:id]">
+	    <xsl:sequence select="ancestor-or-self::*[@xml:id][1]/@xml:id!translate( .,':','')"/>
+	  </xsl:when>
+	  <xsl:when test="ancestor-or-self::constraintDecl">
+	    <xsl:sequence select="'constraintDecl'"/>
+	  </xsl:when>
+	</xsl:choose>
+      </xsl:variable>
       <xsl:value-of
           select="( $scheme,
                    'constraint',
-                    ancestor-or-self::*[@ident]/@ident/translate( .,':',''),
+                    $id,
                     $num )"
           separator="-"/>
     </xsl:for-each>

--- a/odds/extract-isosch.xsl
+++ b/odds/extract-isosch.xsl
@@ -358,53 +358,12 @@ of this software, even if advised of the possibility of such damage.
 
       <xsl:if test="key('CONSTRAINTs', $langs )[ not( self::sch:ns ) ]">
         <xsl:variable name="N"
-		      select="', of which there are '||count( key('CONSTRAINTs', $langs, $root )/*[ not( self::sch:ns ) ] )"/>
+                      select="', of which there are '||count( key('CONSTRAINTs', $langs, $root )/*[ not( self::sch:ns ) ] )"/>
         <xsl:call-template name="blockComment">
           <xsl:with-param name="content" select="'constraints in '||string-join( $langs, ', ')||$N"/>
         </xsl:call-template>
       </xsl:if>
-      <xsl:for-each select="$root/key('CONSTRAINTs', $langs )[ not( self::sch:ns ) ]">
-        <xsl:variable name="patID" select="tei:makePatternID(.)"/>
-	<xsl:message select="'DEBUG: processing '||$patID"/>
-        <xsl:choose>
-          <xsl:when test="sch:pattern">
-	    <xsl:message select="'debug: a pattern child'"/>
-            <!-- IF there is a child <pattern>, we just copy over all children, no tweaking -->
-            <xsl:apply-templates select="node()">
-              <!-- they all get handed $patID, but only the template for 'pattern' uses it -->
-              <xsl:with-param name="patID" select="$patID"/>
-            </xsl:apply-templates>
-          </xsl:when>
-          <xsl:when test="sch:rule">
-	    <xsl:message select="'debug: a rule child'"/>
-            <!-- IF there is no <pattern>, but there is a <rule>, copy over all children -->
-            <!-- into a newly created <pattern> wrapper -->
-            <pattern id="{$patID}">
-              <xsl:apply-templates select="node()"/>
-            </pattern>
-          </xsl:when>
-          <xsl:when test="sch:assert | sch:report | sch:extends">
-	    <xsl:message select="'debug: some other child'"/>
-            <!-- IF there is no <pattern> nor <rule> child, but there is a child that -->
-            <!-- requires being wrapped in a rule, create both <rule> and <pattern> -->
-            <!-- wrappers for them, making HERE the context.   NOTE: As of 2025-03-15 -->
-            <!-- a free-floating <assert> or <report> without a parent <rule> (with a -->
-            <!-- @context attribute) will no longer be allowed, so this entire <when> -->
-            <!-- could maybe be dropped.  See PR TEI #2513. -->
-            <pattern id="{$patID}">
-              <rule context="{tei:generate-context(.)}">
-                <xsl:apply-templates select="node()"/>
-              </rule>
-            </pattern>
-          </xsl:when>
-          <xsl:otherwise>
-	    <xsl:message select="'debug: OTHERWISE'"/>
-            <!-- IF there is neither a <pattern> nor a <rule>, nor a child that would -->
-            <!-- require being wrapped in those, just copy over whatever we have -->
-            <xsl:apply-templates select="node()"/>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:for-each>
+      <xsl:apply-templates select="$root/key('CONSTRAINTs', $langs )[ not( self::sch:ns ) ]"/>
 
       <xsl:if test="key('DEPRECATEDs',1)">
         <xsl:call-template name="blockComment">
@@ -501,17 +460,28 @@ of this software, even if advised of the possibility of such damage.
 
     </schema>
   </xsl:template>
-  
-  <xsl:template match="tei:constraint/sch:rule">
-    <rule>
-      <xsl:apply-templates select="@*"/>
-      <xsl:if test="not(@context)">
-        <!-- note: don't want to call generate-context() if not needed, -->
-        <!-- as we may want it to generate warning msgs -->
-        <xsl:attribute name="context" select="tei:generate-context(.)"/>
-      </xsl:if>
+
+  <xsl:template match="tei:constraint">
+    <xsl:apply-templates select="node()"/>
+  </xsl:template>
+
+  <xsl:template match="tei:constraint/sch:pattern">
+    <xsl:variable name="patID" select="tei:makePatternID( child::sch:pattern[1] )"/>
+    <!-- (Note that makePatternID() will use the @id of <pattern>, if there is one.) -->
+    <pattern id="{$patID}">
       <xsl:apply-templates select="node()"/>
-    </rule>
+    </pattern>
+  </xsl:template>
+
+  <xsl:template match="tei:constraint/sch:rule|tei:constraintDecl/sch:rule">
+    <xsl:variable name="patID" select="tei:makePatternID(.)"/>
+    <!-- IF there is no <pattern>, but there is a <rule>, copy over all children -->
+    <!-- into a newly created <pattern> wrapper -->
+    <pattern id="{$patID}">
+      <rule>
+        <xsl:apply-templates select="@*|node()"/>
+      </rule>
+    </pattern>
   </xsl:template>
   
   <xsl:template match="sch:*|xsl:*">
@@ -595,28 +565,15 @@ of this software, even if advised of the possibility of such damage.
     <xsl:param name="context"/>
     <xsl:variable name="scheme" select="$context/ancestor-or-self::constraintSpec/@scheme|$context/ancestor-or-self::constraintDecl/@scheme"/>
     <xsl:for-each select="$context">
+      <xsl:variable name="id" select="( ancestor-or-self::*[@ident][1]/@ident,
+                                        ancestor-or-self::*[@id][1]/@id,
+                                        ancestor-or-self::*[@xml:id][1]/@xml:id,
+                                        ancestor-or-self::constraintDecl!local-name(.)
+                                      )[1]!translate( .,':','')"/>
       <xsl:variable name="num">
         <xsl:number level="any"/>
       </xsl:variable>
-      <xsl:variable name="id">
-	<xsl:choose>
-	  <xsl:when test="ancestor-or-self::*[@ident]">
-	    <xsl:sequence select="ancestor-or-self::*[@ident][1]/@ident!translate( .,':','')"/>
-	  </xsl:when>
-	  <xsl:when test="ancestor-or-self::*[@xml:id]">
-	    <xsl:sequence select="ancestor-or-self::*[@xml:id][1]/@xml:id!translate( .,':','')"/>
-	  </xsl:when>
-	  <xsl:when test="ancestor-or-self::constraintDecl">
-	    <xsl:sequence select="'constraintDecl'"/>
-	  </xsl:when>
-	</xsl:choose>
-      </xsl:variable>
-      <xsl:value-of
-          select="( $scheme,
-                   'constraint',
-                    $id,
-                    $num )"
-          separator="-"/>
+      <xsl:value-of select="( $scheme, 'constraint', $id, $num )" separator="-"/>
     </xsl:for-each>
   </xsl:function>
   

--- a/odds/extract-isosch.xsl
+++ b/odds/extract-isosch.xsl
@@ -257,7 +257,7 @@ of this software, even if advised of the possibility of such damage.
                                   ||'; using the prefix bound in the first one, '
                                   ||'and ignoring the other(s).'"/>
             </xsl:if>
-            <xsl:sequence select="$DECLARED_NSs_with_this_uri/@prefix => normalize-space()||':'"/>
+            <xsl:sequence select="($DECLARED_NSs_with_this_uri)[1]/@prefix => normalize-space()||':'"/>
           </xsl:when>
           <xsl:when test="namespace::* = $nsu">
             <xsl:value-of select="concat( local-name( namespace::*[ . eq $nsu ][1] ), ':')"/>

--- a/odds/extract-isosch.xsl
+++ b/odds/extract-isosch.xsl
@@ -461,6 +461,10 @@ of this software, even if advised of the possibility of such damage.
     </schema>
   </xsl:template>
 
+  <xsl:template match="tei:constraint[ ../@scheme eq 'schematron' ]/(sch:report|sch:assert)">
+    <xsl:message select="'WARNING: Ignoring invalid '||name(.)||' found directly within &lt;constraint>.'"/>
+  </xsl:template>
+
   <xsl:template match="tei:constraint">
     <xsl:apply-templates select="node()"/>
   </xsl:template>

--- a/odds/extract-isosch.xsl
+++ b/odds/extract-isosch.xsl
@@ -200,13 +200,22 @@ of this software, even if advised of the possibility of such damage.
            match="//tei:*[@validUntil][ not( ancestor::teix:egXML ) ]"
            use="1"/>
 
+  <!--
+      The CONSTRAINTs key contains the <constraint> elements from
+      within <constraintSpec>s plus whatever Schematron elements
+      are in the <constraintDecl>.
+  -->
   <xsl:key name="CONSTRAINTs"
            match="constraintSpec[ @scheme eq 'schematron' ]/constraint
                                 [ not( ancestor::teix:egXML ) ]"
            use="( ancestor-or-self::*[@xml:lang][1]/@xml:lang, 'en')[1] => normalize-space()"/>
+  <xsl:key name="CONSTRAINTs"
+           match="constraintDecl[ @scheme eq 'schematron' ]/sch:*
+                                [ not( ancestor::teix:egXML ) ]"
+           use="( ancestor-or-self::*[@xml:lang][1]/@xml:lang, 'en')[1] => normalize-space()"/>
 
   <xsl:key name="SCHQCKFIXs"
-           match="constraintSpec[ @scheme eq 'schematron' ]//sqf:fixes
+           match="(constraintSpec|constraintDecl)[ @scheme eq 'schematron' ]//sqf:fixes
                                 [ not( ancestor::teix:egXML ) ]"
            use="( ancestor-or-self::*[@xml:lang][1]/@xml:lang, 'en')[1] => normalize-space()"/>
   
@@ -356,7 +365,8 @@ of this software, even if advised of the possibility of such damage.
       </xsl:if>
       
       <xsl:if test="key('CONSTRAINTs', $langs )">
-        <xsl:variable name="N" select="', of which there are '||count( key('CONSTRAINTs', $langs, $root ))"/>
+        <xsl:variable name="N"
+		      select="', of which there are '||count( key('CONSTRAINTs', $langs, $root )/self::constraint )"/>
         <xsl:call-template name="blockComment">
           <xsl:with-param name="content" select="'constraints in '||string-join( $langs, ', ')||$N"/>
         </xsl:call-template>

--- a/odds/extract-isosch.xsl
+++ b/odds/extract-isosch.xsl
@@ -466,7 +466,7 @@ of this software, even if advised of the possibility of such damage.
   </xsl:template>
 
   <xsl:template match="tei:constraint/sch:pattern">
-    <xsl:variable name="patID" select="tei:makePatternID( child::sch:pattern[1] )"/>
+    <xsl:variable name="patID" select="tei:makePatternID(.)"/>
     <!-- (Note that makePatternID() will use the @id of <pattern>, if there is one.) -->
     <pattern id="{$patID}">
       <xsl:apply-templates select="node()"/>

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -551,6 +551,7 @@ of this software, even if advised of the possibility of such damage.
             <xsl:apply-templates select="key('odd2odd-CONSTRAINTDECLS-by-SCHEME', ., $top )"/>
 	  </constraintDecl>
 	</xsl:for-each>
+	<xsl:apply-templates select="tei:encodingDesc/node() except tei:constraintDecl" mode="#current"/>
       </tei:encodingDesc>
     </xsl:if>
   </xsl:template>

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -559,7 +559,7 @@ of this software, even if advised of the possibility of such damage.
 	<!-- … with any attributes the original <encodingDesc> (if any) had … -->
 	<xsl:apply-templates select="tei:encodingDesc/@*" mode="#current"/>
 	<!-- … and any content the original <encodingDesc> (if any) had; -->
-	<xsl:apply-templates select="tei:encodingDesc/node() except tei:constraintDecl" mode="pass0"/>
+	<xsl:apply-templates select="tei:encodingDesc/node() except //tei:constraintDecl" mode="pass0"/>
 	<!-- … then get the list of schemes to which the <constraintDecl>s apply … -->
 	<xsl:variable name="constraintDecl_schemes" select="$constraintDecls/@scheme" as="xs:string*"/>
 	<!-- … and for each such (unique) scheme … -->

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -142,6 +142,8 @@ of this software, even if advised of the possibility of such damage.
   <xsl:key name="odd2odd-REPLACE"    match="tei:macroSpec[@mode eq 'replace']"   use="tei:uniqueName(.)"/>
   <xsl:key name="odd2odd-REPLACEATT" match="tei:attDef[@mode eq 'replace']" use="concat(../../@ident,'_',@ident)"/>
 
+  <xsl:key name="odd2odd-CONSTRAINTDECLS-by-SCHEME" match="tei:constraintDecl" use="@scheme"/>
+
   <xsl:variable name="DEFAULTSOURCE">
     <xsl:choose>
       <xsl:when test="$defaultSource != ''">
@@ -498,15 +500,6 @@ of this software, even if advised of the possibility of such damage.
     </xsl:choose>
   </xsl:template>
   
-  <xsl:template match="@*|processing-instruction()|text()|comment()" mode="pass0">
-      <xsl:copy/>
-  </xsl:template>  
-  <xsl:template match="*" mode="pass0">
-    <xsl:copy>
-      <xsl:apply-templates select="@*|node()" mode="pass0"/>
-    </xsl:copy>
-  </xsl:template>
-
   <xsl:template match="tei:elementSpec[@mode eq 'change']|tei:classSpec[@mode eq 'change']|tei:macroSpec[@mode eq 'change']|tei:dataSpec[@mode eq 'change']" mode="pass0">    
     <xsl:variable name="CURRENT_ID" select="generate-id(.)"/>
     <xsl:variable name="CHANGED_SPECS" select="key('odd2odd-CHANGE',tei:uniqueName(.))" 
@@ -532,6 +525,43 @@ of this software, even if advised of the possibility of such damage.
         </xsl:copy>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="tei:teiHeader" mode="pass0">
+    <xsl:copy>
+      <xsl:apply-templates select="@*" mode="#current"/>
+      <xsl:apply-templates select="tei:fileDesc" mode="#current"/>
+      <xsl:call-template name="insert_encodingDesc_if_needed"/>
+      <xsl:apply-templates select="tei:profileDesc" mode="#current"/>
+      <xsl:apply-templates select="tei:xenoData" mode="#current"/>
+      <xsl:apply-templates select="tei:revisionDesc" mode="#current"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template name="insert_encodingDesc_if_needed">
+    <xsl:variable name="constraintDecls" as="element(tei:constraintDecl)*"
+		  select="( document(tei:workOutSource(.))//tei:constraintDecl, //tei:constraintDecl )"/>
+    <xsl:if test="child::tei:encodingDesc or count( $constraintDecls ) > 0">
+      <tei:encodingDesc>
+	<xsl:apply-templates select="tei:encodingDesc/@*" mode="#current"/>
+	<xsl:variable name="constraintDecl_schemes" select="$constraintDecls/@scheme" as="xs:string*"/>
+	<xsl:for-each select="distinct-values( $constraintDecl_schemes )">
+	  <constraintDecl scheme="{.}">
+            <xsl:apply-templates select="key('odd2odd-CONSTRAINTDECLS-by-SCHEME', ., document(tei:workOutSource( $top )) )"/>
+            <xsl:apply-templates select="key('odd2odd-CONSTRAINTDECLS-by-SCHEME', ., $top )"/>
+	  </constraintDecl>
+	</xsl:for-each>
+      </tei:encodingDesc>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="@*|processing-instruction()|text()|comment()" mode="pass0">
+      <xsl:copy/>
+  </xsl:template>  
+  <xsl:template match="*" mode="pass0">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" mode="pass0"/>
+    </xsl:copy>
   </xsl:template>
 
   <!-- ******************* Phase 1, expand schemaSpec ********************************* -->

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -142,8 +142,6 @@ of this software, even if advised of the possibility of such damage.
   <xsl:key name="odd2odd-REPLACE"    match="tei:macroSpec[@mode eq 'replace']"   use="tei:uniqueName(.)"/>
   <xsl:key name="odd2odd-REPLACEATT" match="tei:attDef[@mode eq 'replace']" use="concat(../../@ident,'_',@ident)"/>
 
-  <xsl:key name="odd2odd-CONSTRAINTDECLS-by-SCHEME" match="tei:constraintDecl" use="@scheme"/>
-
   <xsl:variable name="DEFAULTSOURCE">
     <xsl:choose>
       <xsl:when test="$defaultSource != ''">
@@ -539,19 +537,40 @@ of this software, even if advised of the possibility of such damage.
   </xsl:template>
 
   <xsl:template name="insert_encodingDesc_if_needed">
+    <!-- Get an easy-reference version of the <schemaSpec> we are currently processing: -->
+    <xsl:variable name="this_schemaSpec" as="element(tei:schemaSpec)" select="$top//tei:schemaSpec[ @ident eq $whichSchemaSpec ]"/>
+    <!-- Get a copy of the source (or base) ODD: -->
+    <xsl:variable name="source" as="document-node()" select="document( tei:workOutSource( $this_schemaSpec ) )"/>
+    <!-- Assemble a set of all the relevant <constraintDecl>s: -->
     <xsl:variable name="constraintDecls" as="element(tei:constraintDecl)*"
-		  select="( document(tei:workOutSource(.))//tei:constraintDecl, //tei:constraintDecl )"/>
-    <xsl:if test="child::tei:encodingDesc or count( $constraintDecls ) > 0">
+		  select="(
+			    $source//tei:constraintDecl,
+			    $top//tei:teiHeader//tei:constraintDecl,
+			    $this_schemaSpec//tei:constraintDecl
+			  )"/>
+    <!--
+	If there already is an <encodingDesc> (in which case we need
+	to copy it over) OR there are one or more <constraintDecl>s
+	whose contents we need to preserve for future use …
+    -->
+    <xsl:if test="child::tei:encodingDesc  or  count( $constraintDecls ) gt 0">
+      <!-- … output an <encodingDesc> … -->
       <tei:encodingDesc>
+	<!-- … with any attributes the original <encodingDesc> (if any) had … -->
 	<xsl:apply-templates select="tei:encodingDesc/@*" mode="#current"/>
+	<!-- … and any content the original <encodingDesc> (if any) had; -->
+	<xsl:apply-templates select="tei:encodingDesc/node() except tei:constraintDecl" mode="pass0"/>
+	<!-- … then get the list of schemes to which the <constraintDecl>s apply … -->
 	<xsl:variable name="constraintDecl_schemes" select="$constraintDecls/@scheme" as="xs:string*"/>
+	<!-- … and for each such (unique) scheme … -->
 	<xsl:for-each select="distinct-values( $constraintDecl_schemes )">
-	  <constraintDecl scheme="{.}">
-            <xsl:apply-templates select="key('odd2odd-CONSTRAINTDECLS-by-SCHEME', ., document(tei:workOutSource( $top )) )"/>
-            <xsl:apply-templates select="key('odd2odd-CONSTRAINTDECLS-by-SCHEME', ., $top )"/>
-	  </constraintDecl>
+	  <xsl:variable name="this_scheme" select="."/>
+	  <!-- … create an output <constraintDecl> here in the <encodingDesc> … -->
+	  <tei:constraintDecl scheme="{$this_scheme}">
+	    <!-- … that has the contents of *all* the applicable <constraintDecl>s for this scheme … -->
+            <xsl:apply-templates select="$constraintDecls[ @scheme eq $this_scheme ]/node()" mode="pass0"/>
+	  </tei:constraintDecl>
 	</xsl:for-each>
-	<xsl:apply-templates select="tei:encodingDesc/node() except tei:constraintDecl" mode="#current"/>
       </tei:encodingDesc>
     </xsl:if>
   </xsl:template>
@@ -617,11 +636,20 @@ of this software, even if advised of the possibility of such damage.
     <xsl:copy-of select="."/>
   </xsl:template>
 
-  <xsl:template match="tei:elementSpec[@mode eq 'delete']|tei:classSpec[@mode eq 'delete']|tei:macroSpec[@mode eq 'delete']|tei:dataSpec[@mode eq 'delete']"
+  <xsl:template match="tei:schemaSpec//tei:constraintDecl" mode="pass1">
+    <xsl:if test="$verbose='true'">
+      <xsl:message>Phase 1: remove constraintDecl, as its contents have already been copied to teiHeader/encodingDesc/constraintDecl</xsl:message>
+    </xsl:if>
+  </xsl:template>
+  
+  <xsl:template match=" tei:elementSpec[@mode eq 'delete']
+		       |tei:classSpec[@mode eq 'delete']
+		       |tei:macroSpec[@mode eq 'delete']
+		       |tei:dataSpec[@mode eq 'delete']"
                 mode="pass1">
-        <xsl:if test="$verbose='true'">
-          <xsl:message>Phase 1: remove <xsl:value-of select="@ident"/></xsl:message>
-        </xsl:if>
+    <xsl:if test="$verbose='true'">
+      <xsl:message>Phase 1: remove <xsl:value-of select="@ident"/></xsl:message>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="tei:elementSpec|tei:classSpec|tei:macroSpec|tei:dataSpec"

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -543,34 +543,53 @@ of this software, even if advised of the possibility of such damage.
     <xsl:variable name="source" as="document-node()" select="document( tei:workOutSource( $this_schemaSpec ) )"/>
     <!-- Assemble a set of all the relevant <constraintDecl>s: -->
     <xsl:variable name="constraintDecls" as="element(tei:constraintDecl)*"
-		  select="(
-			    $source//tei:constraintDecl,
-			    $top//tei:teiHeader//tei:constraintDecl,
-			    $this_schemaSpec//tei:constraintDecl
-			  )"/>
+                  select="(
+                            $source//tei:constraintDecl,
+                            $top//tei:teiHeader//tei:constraintDecl,
+                            $this_schemaSpec//tei:constraintDecl
+                          )"/>
     <!--
-	If there already is an <encodingDesc> (in which case we need
-	to copy it over) OR there are one or more <constraintDecl>s
-	whose contents we need to preserve for future use …
+        If there already is an <encodingDesc> (in which case we need
+        to copy it over) OR there are one or more <constraintDecl>s
+        whose contents we need to preserve for future use …
     -->
     <xsl:if test="child::tei:encodingDesc  or  count( $constraintDecls ) gt 0">
       <!-- … output an <encodingDesc> … -->
       <tei:encodingDesc>
-	<!-- … with any attributes the original <encodingDesc> (if any) had … -->
-	<xsl:apply-templates select="tei:encodingDesc/@*" mode="#current"/>
-	<!-- … and any content the original <encodingDesc> (if any) had; -->
-	<xsl:apply-templates select="tei:encodingDesc/node() except //tei:constraintDecl" mode="pass0"/>
-	<!-- … then get the list of schemes to which the <constraintDecl>s apply … -->
-	<xsl:variable name="constraintDecl_schemes" select="$constraintDecls/@scheme" as="xs:string*"/>
-	<!-- … and for each such (unique) scheme … -->
-	<xsl:for-each select="distinct-values( $constraintDecl_schemes )">
-	  <xsl:variable name="this_scheme" select="."/>
-	  <!-- … create an output <constraintDecl> here in the <encodingDesc> … -->
-	  <tei:constraintDecl scheme="{$this_scheme}">
-	    <!-- … that has the contents of *all* the applicable <constraintDecl>s for this scheme … -->
+        <!-- … with any attributes the original <encodingDesc> (if any) had … -->
+        <xsl:apply-templates select="tei:encodingDesc/@*" mode="#current"/>
+        <!-- … and any content the original <encodingDesc> (if any) had; -->
+        <xsl:apply-templates select="tei:encodingDesc/node() except //tei:constraintDecl" mode="pass0"/>
+        <!-- … then get the list of schemes to which the <constraintDecl>s apply … -->
+        <xsl:variable name="constraintDecl_schemes" select="$constraintDecls/@scheme" as="xs:string*"/>
+        <!-- … and for each such (unique) scheme … -->
+        <xsl:for-each select="distinct-values( $constraintDecl_schemes )">
+          <xsl:variable name="this_scheme" select="."/>
+          <!-- … create an output <constraintDecl> here in the <encodingDesc> … -->
+          <tei:constraintDecl scheme="{$this_scheme}">
+            <xsl:attribute name="queryBinding">
+              <xsl:variable name="queryBindings" as="xs:string*"
+                            select="$constraintDecls[ @scheme eq $this_scheme ]/@queryBinding!normalize-space()"/>
+              <xsl:variable name="distinct-queryBindings" as="xs:string*"
+                            select="distinct-values( $queryBindings )"/>
+              <xsl:choose>
+                <xsl:when test="count( $distinct-queryBindings ) eq 0">xslt2</xsl:when>
+                <xsl:when test="count( $distinct-queryBindings ) eq 1"><xsl:sequence select="$distinct-queryBindings"/></xsl:when>
+                <xsl:otherwise>
+                  <xsl:variable name="queryBinding" select="($constraintDecls[ @scheme eq $this_scheme ]/@queryBinding)[last()]"/>
+                  <xsl:message expand-text="yes">Warning: multiple
+                  query bindings for {$this_scheme} constraints
+                  specified in input ODDs (<xsl:value-of
+                  select="$distinct-queryBindings" separator=", "/>).
+                  Output combined ODD will specify {$queryBinding}.</xsl:message>
+                  <xsl:sequence select="$queryBinding"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:attribute>
+            <!-- … that has the contents of *all* the applicable <constraintDecl>s for this scheme … -->
             <xsl:apply-templates select="$constraintDecls[ @scheme eq $this_scheme ]/node()" mode="pass0"/>
-	  </tei:constraintDecl>
-	</xsl:for-each>
+          </tei:constraintDecl>
+        </xsl:for-each>
       </tei:encodingDesc>
     </xsl:if>
   </xsl:template>
@@ -643,9 +662,9 @@ of this software, even if advised of the possibility of such damage.
   </xsl:template>
   
   <xsl:template match=" tei:elementSpec[@mode eq 'delete']
-		       |tei:classSpec[@mode eq 'delete']
-		       |tei:macroSpec[@mode eq 'delete']
-		       |tei:dataSpec[@mode eq 'delete']"
+                       |tei:classSpec[@mode eq 'delete']
+                       |tei:macroSpec[@mode eq 'delete']
+                       |tei:dataSpec[@mode eq 'delete']"
                 mode="pass1">
     <xsl:if test="$verbose='true'">
       <xsl:message>Phase 1: remove <xsl:value-of select="@ident"/></xsl:message>
@@ -1697,14 +1716,14 @@ of this software, even if advised of the possibility of such damage.
     <xsl:if test="$ORIGINAL/self::tei:elementSpec">
       <xsl:apply-templates mode="justcopy"
                            select="tei:attList/tei:attDef
-				   [
-				     (    @mode eq 'change'
+                                   [
+                                     (    @mode eq 'change'
                                        or @mode eq 'delete'
                                        or @mode eq 'replace'
-				     )
-				     and
+                                     )
+                                     and
                                      not( @ident = $ORIGINAL/tei:attList//tei:attDef/@ident )
-				   ]"/>
+                                   ]"/>
     </xsl:if>
     <!-- any direct attRef elements -->
     <xsl:apply-templates mode="justcopy"

--- a/odds/odd2relax.xsl
+++ b/odds/odd2relax.xsl
@@ -128,7 +128,10 @@ of this software, even if advised of the possibility of such damage.
           <xsl:call-template name="schemaSpecBody"/>
         </xsl:otherwise>
       </xsl:choose>
-      <xsl:apply-templates select="tei:constraintSpec"/>
+      <xsl:apply-templates
+	  select=" tei:constraintSpec
+		  |tei:constraintDecl[ @scheme eq 'schematron']
+		  |ancestor::tei:TEI/tei:teiHeader//tei:constraintDecl[ @scheme eq 'schematron']"/>
     </xsl:variable>
     <xsl:call-template name="generateOutput">
       <xsl:with-param name="method">xml</xsl:with-param>

--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -2482,10 +2482,14 @@ of this software, even if advised of the possibility of such damage.
     </xsl:for-each>
   </xsl:template>
 
-  <xsl:template match="tei:constrainSpec|tei:constraint">
+  <xsl:template match="tei:constraintSpec|tei:constraint">
     <xsl:apply-templates/>
   </xsl:template>
 
+  <xsl:template match="tei:constraintDecl[ @scheme eq 'schematron']">
+    <xsl:apply-templates select="sch:*" mode="justcopy"/>
+  </xsl:template>
+  
   <xsl:template match="sch:*">
     <xsl:call-template name="processSchematron"/>
   </xsl:template>


### PR DESCRIPTION
[Note: There is no issue married to this PR.]

Wow. I first found a teeny bug in extract-isosch.xsl which occurred in the case of more than one prefix bound to a particular namespace URI. A warning message told the user that only the 1st prefix would be used, but the code tried to use all of them, and thus failed kinda dramatically.

But while fixing & testing this _tiny_ bug fix (only changes 1 line of code), I realized that our entire processing chain pretty much ignored a `<constraintDecl>` that is in the base (or source) ODD.

So I added code to odd2odd.xsl that will (I hope) merge both the `<constraintDecl>`s from the customization ODD with those from the base ODD on a scheme-by-scheme basis, putting the result in the `<encodingDesc>` of the output compiled ODD. I then added code to extract-isosch.xsl to pay attention to `<constraintDecl>`s wherever they may be.

This code passes both Test/ and Test2/, and I was able to build the WWP schema using this branch. (Which says something, because it is a big customization that has a lot of Schematron.)