### PR TITLE
copy over `tei:constraint/sch:pattern` attributes into output Schematron

### DIFF
--- a/odds/extract-isosch.xsl
+++ b/odds/extract-isosch.xsl
@@ -473,7 +473,7 @@ of this software, even if advised of the possibility of such damage.
     <xsl:variable name="patID" select="tei:makePatternID(.)"/>
     <!-- (Note that makePatternID() will use the @id of <pattern>, if there is one.) -->
     <pattern id="{$patID}">
-      <xsl:apply-templates select="node()"/>
+      <xsl:apply-templates select="@*|node()"/>
     </pattern>
   </xsl:template>
 


### PR DESCRIPTION
Bug fix: we were failing to copy over the attributes of a `<sch:pattern>` when it was a child of an input `<tei:constraint>`. 

P.S. It is worth noting that such attributes, except for `@id` which we were handling, are quite rare. We do not use them internally, yet. The only ones I found in my entire TEI/, Stylesheets/, and ATOP/ hierarchies were those in the leftover files from my attempt to use abstract patterns to enforce the constraints of declarable elements (which, somewhat shockingly, was 3 years ago to the day, so I did a double-take on the date :​-​), and a snippet of the XSpec test suite which is in the ATOP library. Thus, unless a user complains, it may not be worth a patch release.