### PR TITLE
Update target link to TCW 27 for deprecation warnings 

### DIFF
--- a/common/common_tagdocs.xsl
+++ b/common/common_tagdocs.xsl
@@ -3219,7 +3219,7 @@
               <xsl:call-template name="makeExternalLink">
                 <xsl:with-param name="ptr" select="false()"/>
                 <xsl:with-param name="dest">
-                  <xsl:text>http://www.tei-c.org/Activities/Council/Working/tcw27.xml</xsl:text>
+                  <xsl:text>https://tei-c.org/documentation/tcw27/</xsl:text>
                 </xsl:with-param>
               </xsl:call-template>
             </xsl:for-each>

--- a/common/common_tagdocs.xsl
+++ b/common/common_tagdocs.xsl
@@ -2018,7 +2018,7 @@
                   <xsl:call-template name="makeExternalLink">
                     <xsl:with-param name="ptr" select="false()"/>
                     <xsl:with-param name="dest">
-                      <xsl:text>http://www.tei-c.org/Activities/Council/Working/tcw27.xml</xsl:text>
+                      <xsl:text>https://tei-c.org/documentation/tcw27/</xsl:text>
                     </xsl:with-param>
                   </xsl:call-template>
                 </xsl:for-each>


### PR DESCRIPTION
Updated the target links to TCW 27 for deprecation warnings in [Stylesheets/common/common_tagdocs.xsl](https://github.com/TEIC/Stylesheets/blob/0aee6b342f731704d75c61b93edeac572d4b8501/common/common_tagdocs.xsl#L2021) for #694 

However, still need to check if there may be a redirecting issue with the web server as suggested by @peterstadler. 