### PR TITLE
Set fork to true for all java tasts to work around security manager issue

### DIFF
--- a/Test2/build.xml
+++ b/Test2/build.xml
@@ -135,7 +135,7 @@
             uses Trang to convert the first to the second.
         </description>
         <echo level="info" message="Convert ${rngIn} to ${rncOut} using Trang."/>
-        <java classname="com.thaiopensource.relaxng.translate.Driver" fork="no">
+        <java classname="com.thaiopensource.relaxng.translate.Driver" fork="true">
             <classpath location="${trang}"/>
             <arg value="-O"/>
             <arg value="rnc"/>

--- a/rnc/build-to.xml
+++ b/rnc/build-to.xml
@@ -30,7 +30,7 @@
     <oddexpand in="${inputFile}" out="${inputFile}.processedodd"/>
     <buildgeneric type="relaxng" xsl="${profiledir}/${profile}/rng/to.xsl" in="${inputFile}.processedodd" out="${outputFile}.rng"/>
     <echo level="info">TRANG generate RNC from RELAXNG files</echo>
-    <java classname="com.thaiopensource.relaxng.translate.Driver" fork="no">
+    <java classname="com.thaiopensource.relaxng.translate.Driver" fork="true">
       <classpath>
         <path refid="classpath"/>
         <pathelement location="${trang.jar}"/>

--- a/xsd/build-to.xml
+++ b/xsd/build-to.xml
@@ -30,7 +30,7 @@
     <oddexpand in="${inputFile}" out="${inputFile}.processedodd"/>
     <buildgeneric type="relaxng" xsl="${profiledir}/${profile}/rng/to.xsl" in="${inputFile}.processedodd" out="${outputFile}.rng"/>
     <echo level="info">TRANG generate XSD from RELAXNG files</echo>
-    <java classname="com.thaiopensource.relaxng.translate.Driver" fork="no">
+    <java classname="com.thaiopensource.relaxng.translate.Driver" fork="true">
       <classpath>
         <path refid="classpath"/>
         <pathelement location="${trang.jar}"/>


### PR DESCRIPTION
If you could test this in the Docker image, that would be useful. It works locally for me, and I don't see how it could break functionality in Docker, but you never know. Fix for issue #742.