### PR TITLE
Fix Illegal character in ODD path on Windows

### DIFF
--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -240,6 +240,9 @@ of this software, even if advised of the possibility of such damage.
           <xsl:value-of select="$currentDirectory"/>
           <xsl:value-of select="$loc"/>
         </xsl:when>
+        <xsl:when test="matches($currentDirectory, '^[A-Z]:\\')">
+          <xsl:value-of select="string-join(('file:///', translate($currentDirectory, '\', '/'), $loc), '/')"/>
+        </xsl:when>
         <xsl:when test="$currentDirectory=''">
           <xsl:value-of select="resolve-uri($loc,base-uri($top))"/>
         </xsl:when>

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -241,7 +241,8 @@ of this software, even if advised of the possibility of such damage.
           <xsl:value-of select="$loc"/>
         </xsl:when>
         <xsl:when test="matches($currentDirectory, '^[A-Z]:\\')">
-          <xsl:value-of select="string-join(('file:///', translate($currentDirectory, '\', '/'), $loc), '/')"/>
+          <xsl:value-of select="string-join(('file://', if(matches($currentDirectory, '^[A-Z]:\\$')) 
+            then  translate($currentDirectory, '\', '') else translate($currentDirectory, '\', '/'), $loc), '/')"/>
         </xsl:when>
         <xsl:when test="$currentDirectory=''">
           <xsl:value-of select="resolve-uri($loc,base-uri($top))"/>


### PR DESCRIPTION
Fixes issues on Windows machine, where `$currentDirectory` variable contains path in Windows format, for example `C:\Data\Works`.

This type of path occurs, for example, in the oXygen XML Editor, where the path is passed to ANT in the `inputFile` parameter as the editor variable `${cf}`.

In Windows, this led to the following error:

```text
ransformation failed. 
Fatal error during transformation using C:\Users\Boris\AppData\Roaming\com.oxygenxml\extensions\v27.1\frameworks\tei\tei\xml\tei\stylesheet\odds\odd2odd.xsl: Relative URI {C:\Data\Works...} is invalid: Illegal character in opaque part at index 2: C:\Data\Works\odd/sample.odd; SystemID: file:/C:/Users/Boris/AppData/Roaming/com.oxygenxml/extensions/v27.1/frameworks/tei/tei/xml/tei/stylesheet/odds/odd2odd.xsl; Line#: 247; Column#: 25
```