### PR TITLE
improve Test/ process — optionally move comparisons to end of Makefile itself

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -12,9 +12,9 @@
 # aftwer we are done with everything else?
 DIFFEND=0			# 0 = do diff now; 1 = do diffs at end of processing
 
-DIFFSWITCHES=" "		# switches user can pass in to # override — not yet implemented
-S4D1=-C0 -bBw			# switches used for most calls to diff
-S4DR=-C0 -bBw -r		# switches used for recursive diff
+DIFFSWITCHES=     		 # switches user can pass in to override
+S4D1=-C0 -bBw $(DIFFSWITCHES)	 # switches used for most calls to diff
+S4DR=-C0 -bBw -r $(DIFFSWITCHES) # switches used for recursive diff
 
 DIFFOUT=./DIFFALL.bash	# path to output program to be run (iff DIFFEND=1)
 
@@ -659,5 +659,11 @@ oddtree:
 dodiff:
 	@echo "--------- Test/Makefile target=$@"
 	@if [ -f $(DIFFOUT) ]; then chmod a+x $(DIFFOUT); fi
-	@if [ $(DIFFEND) -eq 1 ]; then echo " "; echo " "; echo "========= comparisons ========="; fi
-	@if [ $(DIFFEND) -eq 1 ]; then bash -c $(DIFFOUT); fi
+	@if [ $(DIFFEND) -eq 1 ]; then                       \
+		echo " ";                                    \
+		echo " ";                                    \
+		echo "========= comparisons =========";      \
+	        bash -c $(DIFFOUT);                          \
+		echo " ";                                    \
+		echo "If you would like to repeat the comparisons, issue \`$(DIFFOUT)\` at the commandline in this directory."; \
+		fi

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -16,7 +16,7 @@ DIFFSWITCHES=" "		# switches user can pass in to # override — not yet implemen
 S4D1=-C0 -bBw			# switches used for most calls to diff
 S4DR=-C0 -bBw -r		# switches used for recursive diff
 
-DIFFOUT=/tmp/DIFFEM.bash	# path to output program to be run (iff DIFFEND=1)
+DIFFOUT=./DIFFALL.bash	# path to output program to be run (iff DIFFEND=1)
 
 # Macro for calling diff cmd
 DIFFFUNC="if [ $(DIFFEND) -eq 0 ]; then diff $(1) $(2) $(3) ; else echo 'echo diff $(1) $(2) $(3); diff $(1) $(2) $(3)' >> $(DIFFOUT) ; fi"
@@ -649,6 +649,7 @@ clean:
 	rm -f teitopdf.result.* *~
 	rm -f dcr.tmp xml.tmp
 	rm -fr $(AR)/ charts/ embeddings/ media/ Pictures/
+	rm -f $(DIFFOUT)
 
 oddtree:
 	@echo "--------- Test/Makefile target=$@"
@@ -657,7 +658,6 @@ oddtree:
 
 dodiff:
 	@echo "--------- Test/Makefile target=$@"
-	chmod a+x $(DIFFOUT)
+	@if [ -f $(DIFFOUT) ]; then chmod a+x $(DIFFOUT); fi
 	@if [ $(DIFFEND) -eq 1 ]; then echo " "; echo " "; echo "========= comparisons ========="; fi
 	@if [ $(DIFFEND) -eq 1 ]; then bash -c $(DIFFOUT); fi
-

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -9,9 +9,17 @@
 
 # Do we perform comparisons between the actual outputs and expected
 # outputs now (and thus fail as soon as there is a difference), or
-# not (in which case user is expected to compare them after we're
-# done building them here)?
-DIFFNOW=1			# 1 = do diff now; 0 = don't do diffs now
+# aftwer we are done with everything else?
+DIFFEND=0			# 0 = do diff now; 1 = do diffs at end of processing
+
+DIFFSWITCHES=" "		# switches user can pass in to override
+S4D1=-C0 -bBw			# switches used for most calls to diff
+S4DR=-C0 -bBw -r		# switches used for recursive diff
+
+DIFFOUT=/tmp/DIFFEM.bash	# path to output program to be run (iff DIFFEND=1)
+
+# Macro for calling diff cmd
+DIFFFUNC="if [ $(DIFFEND) -eq 0 ]; then diff $(1) $(2) $(3) ; else echo 'echo diff $(1) $(2) $(3); diff $(1) $(2) $(3)' >> $(DIFFOUT) ; fi"
 
 # Directories for holding outputs and expected outputs
 # (NB—no ending slashes):
@@ -78,7 +86,7 @@ SCHEMASCRIPTS=teitornc \
 # (no matter what its name).  #
 ###############################
 
-default: actual test.rng test-to-html test-p4top5 test-oddity test-scripts test-namespaces test-from-html test-latex test-fo test-to-docx test-from-docx test-xlsx test-rdf test-text test-odt test-markdown test-cocoa test-epub
+default: actual test.rng test-to-html test-p4top5 test-oddity test-scripts test-namespaces test-from-html test-latex test-fo test-to-docx test-from-docx test-xlsx test-rdf test-text test-odt test-markdown test-cocoa test-epub dodiff
 
 
 ###################
@@ -93,51 +101,29 @@ help:
 	@echo ""
 	@echo "Lots of tests are run by default. For the majority of them, the test generates"
 	@echo "some output (put into $(AR)/) which is to be compared to the expected"
-	@echo "output of that test (stored in $(ER)/). If the parameter DIFFNOW is"
-	@echo "set to 1 (the default), the results of each test are compared to the expected"
+	@echo "output of that test (stored in $(ER)/). If the parameter DIFFEND is"
+	@echo "set to 0 (the default), the results of each test are compared to the expected"
 	@echo "result immediately, and the process fails and stops if a difference is found."
-	@echo "If the parameter DIFFNOW is set to 0 (or anything not '1', really), then the"
-	@echo "comparison is deferred. This allows the user to compare them all at once after"
-	@echo "the entire test has run. This DIFFNOW=0 is often easier for interactive use,"
-	@echo "but DIFFNOW=1 better for running from another process that needs to know if"
-	@echo "there is a failure."
+	@echo "If the parameter DIFFEND is set to 1, then the comparison is deferred until"
+	@echo "after all other processing. Thus DIFFEND=0 has the advantage of stopping a the"
+	@echo "first error, but DIFFEND=1 is potentially a lot faster, as there is no need to"
+	@echo "re-run the entire suite after each error is fixed. "
 	@echo ""
 	@echo "Suggested sequence for interactive use is:"
 	@echo "$$ make clean"
-	@echo "$$ make DIFFNOW=0"
-	@echo "$$ diff -C0 -r $(AR)/ $(ER)/ | perl -pe 's,^diff -C0," '\\n\\n#########\\ndiff' " -C0,;'"
-	@echo "$$ # note: ignore differences in files ending in '.listing'; if there are any use:"
-	@echo '$$ for f in $(AR)/*.listing ; do diff -C0 <(sort $$f) <(sort $(ER)/$$(basename $$f)); done'
-	@echo "$$ # as the sort order is apparently inconsequential."
+	@echo "$$ make DIFFEND=1"
 	@echo ""
-	@echo "When the diff of the two directories is performed, the following files are"
-	@echo "expected to be in only $(AR)/, not $(ER)/. (Listed here"
-	@echo "in the likely order in which they will be listed by diff.)"
-	@echo "  Only in $(AR)/: oddbyexample.dtd"
-	@echo "  Only in $(AR)/: oddbyexample.rnc"
-	@echo "  Only in $(AR)/: oddbyexample.xsd"
-	@echo "  Only in $(AR)/: Pictures"
-	@echo "  Only in $(AR)/: test34.combined.odd"
-	@echo "  Only in $(AR)/: test_3.epub"
-	@echo "  Only in $(AR)/: test3.html"
-	@echo "  Only in $(AR)/: test4.html"
-	@echo "  Only in $(AR)/: testoucscoursesp5.xml"
-	@echo "  Only in $(AR)/: testoucscourses.xml.docx"
-	@echo "  Only in $(AR)/: test-pages.epub"
-	@echo "  Only in $(AR)/: test.processedodd"
-	@echo "  Only in $(AR)/: xml.tmp"
 
 actual:
 	mkdir -p $(AR)
+	if [ $(DIFFEND) -eq 1 ]; then echo "#!/bin/bash" > $(DIFFOUT) ; fi
 
 test.rng: actual
 	@echo "--------- Test/Makefile target=$@"
 	$(BINDIR)/teitorng $(FLAGS) --odd test.odd test.rng
 	xmllint --format test.rng > $(AR)/test.rng && rm test.rng
 	perl -i -pe 'BEGIN{undef $$/;} s/<!--\n ?Schema[^>]+>//smg' $(AR)/test.rng
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.rng $(ER)/test.rng; \
-		else echo "==deferring: \`diff  $(AR)/test.rng $(ER)/test.rng\`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.rng,$(ER)/test.rng)
 
 # I believe the css: target does nothing except ensure that there are symlinks here
 # in the Stylesheets/ directory to each CSS file in the Stylesheets/css/ directory.
@@ -149,67 +135,48 @@ css:
 test-to-html: actual css
 	@echo "--------- Test/Makefile target=$@"
 	$(SAXON)  test.xml ../html/html.xsl cssFile=../tei.css $(SAXONOPT) | tidy -config config_tidy.txt - > $(AR)/test.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.html $(ER)/test.html; \
-		else echo "==deferring: \` diff  $(AR)/test.html $(ER)/test.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.html,$(ER)/test.html)
 
 	$(SAXON) $(AR)/test.html checklinks.xsl
 	$(SAXON) test.xml ../html/html.xsl cssFile=../tei.css pageLayout=Complex  $(SAXONOPT)  | tidy -config config_tidy.txt - > $(AR)/test-complex.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test-complex.html $(ER)/test-complex.html; \
-		else echo "==deferring: \` diff  $(AR)/test-complex.html $(ER)/test-complex.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-complex.html,$(ER)/test-complex.html)
 
 	$(SAXON) test.xml ../profiles/ota/html/to.xsl cssFile=../tei.css $(SAXONOPT)  | tidy -config config_tidy.txt - | perl cleanup.pl > $(AR)/test-ota.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test-ota.html $(ER)/test-ota.html; \
-		else echo "==deferring: \` diff  $(AR)/test-ota.html $(ER)/test-ota.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-ota.html,$(ER)/test-ota.html)
 
 	$(BINDIR)/teitohtml5 $(FLAGS) test.xml $(AR)/test.html5
 	tidy -config config_tidy.txt $(AR)/test.html5 | perl cleanup.pl > test.temp
 	mv test.temp $(AR)/test.html5
-	if [ $(DIFFNOW) -eq 1 ]; \
+	if [ $(DIFFEND) -eq 0 ]; \
 		then diff  $(AR)/test.html5 $(ER)/test.html5; \
 		else echo "==deferring: \` diff  $(AR)/test.html5 $(ER)/test.html5 \`"; fi
 
 	$(SAXON) test20.xml ../html/html.xsl $(SAXONOPT) | tidy -config config_tidy.txt - > $(AR)/test20.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test20.html $(ER)/test20.html; \
-		else echo "==deferring: \` diff  $(AR)/test20.html $(ER)/test20.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test20.html,$(ER)/test20.html)
 
 	$(SAXON) -versionmsg:off  test3.xml ../html/html.xsl $(SAXONOPT)| tidy -config config_tidy.txt - > $(AR)/test3.html
 	$(SAXON) -versionmsg:off  test4.xml ../html/html.xsl $(SAXONOPT)| tidy -config config_tidy.txt - > $(AR)/test4.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test4.html $(AR)/test3.html; \
-		else echo "==deferring: \` diff  $(AR)/test4.html $(AR)/test3.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test4.html,$(AR)/test3.html)
 
 	$(SAXON) test5.xml ../html/html.xsl  autoBlockQuote=true $(SAXONOPT)  | tidy -config config_tidy.txt - > $(AR)/test5.xhtml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test5.xhtml $(ER)/test5.xhtml; \
-		else echo "==deferring: \` diff  $(AR)/test5.xhtml $(ER)/test5.xhtml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test5.xhtml,$(ER)/test5.xhtml)
 #	$(JING) -c xhtml.rnc $(AR)/test5.xhtml
 # The xhtml.rnc schema previously used for validation is not actually an XHTML5 schema, but rather an XHTML 1.1 schema. 
 # Notably, it does not permit @lang, which we need. Thus I have provisionally commented-out the validation against it 
 # until we can set up proper XHTML5 validation. — hbs 2021-09-15.
+
 	$(SAXON) test6.xml ../html/html.xsl  autoBlockQuote=true $(SAXONOPT)  | tidy -config config_tidy.txt - > $(AR)/test6.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test6.html $(ER)/test6.html; \
-		else echo "==deferring: \` diff  $(AR)/test6.html $(ER)/test6.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test6.html,$(ER)/test6.html)
 #	$(JING) -c xhtml.rnc $(AR)/test6.html
 
 	$(SAXON) test14.xml ../html/html.xsl $(SAXONOPT)| tidy -config config_tidy.txt - > $(AR)/test14.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test14.html $(ER)/test14.html; \
-		else echo "==deferring: \` diff  $(AR)/test14.html $(ER)/test14.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test14.html,$(ER)/test14.html)
 
 	$(SAXON) test22.xml ../html/html.xsl $(SAXONOPT)| tidy -config config_tidy.txt - > $(AR)/test22.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test22.html $(ER)/test22.html; \
-		else echo "==deferring: \` diff  $(AR)/test22.html $(ER)/test22.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test22.html,$(ER)/test22.html)
 
 	$(SAXON) test23.xml ../html/html.xsl $(SAXONOPT)| tidy -config config_tidy.txt - > $(AR)/test23.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test23.html $(ER)/test23.html; \
-		else echo "==deferring: \` diff  $(AR)/test23.html $(ER)/test23.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test23.html,$(ER)/test23.html)
 
 	( \
 		mkdir -p $(AR)/testnotes; \
@@ -222,99 +189,71 @@ test-to-html: actual css
 	tidy -config config_tidy.txt $(AR)/testnotes/one.html > x ; mv x $(AR)/testnotes/one.html
 	tidy -config config_tidy.txt $(AR)/testnotes/two.html > x ; mv x $(AR)/testnotes/two.html
 	tidy -config config_tidy.txt $(AR)/testnotes/three.html > x ; mv x $(AR)/testnotes/three.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  -r  $(AR)/testnotes/ $(ER)/testnotes; \
-		else echo "==deferring: \` diff  -r  $(AR)/testnotes/ $(ER)/testnotes \`"; fi
+	bash -c $(call DIFFFUNC,$(S4DR),$(AR)/testnotes/,$(ER)/testnotes)
 
 	(mkdir -p $(AR)/testnotes2; cd $(AR)/testnotes2;$(UP2SAXON) ../../testnotes2.xml ../../../html/html.xsl splitLevel=0 useFixedDate=true STDOUT=false cssFile=../../../tei.css)
 	tidy -config config_tidy.txt $(AR)/testnotes2/index.html > x ; mv x $(AR)/testnotes2/index.html
 	tidy -config config_tidy.txt $(AR)/testnotes2/one.html > x ; mv x $(AR)/testnotes2/one.html
 	tidy -config config_tidy.txt $(AR)/testnotes2/three.html > x ; mv x $(AR)/testnotes2/three.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  -r  $(AR)/testnotes2 $(ER)/testnotes2; \
-		else echo "==deferring: \` diff  -r  $(AR)/testnotes2 $(ER)/testnotes2 \`"; fi
+	bash -c $(call DIFFFUNC,$(S4DR),$(AR)/testnotes2,$(ER)/testnotes2)
 
 	(mkdir -p $(AR)/testnotes3; cd $(AR)/testnotes3;$(UP2SAXON) ../../testnotes2.xml ../../../html/html.xsl splitLevel=4 useFixedDate=true STDOUT=false cssFile=../../../tei.css)
 	tidy -config config_tidy.txt $(AR)/testnotes3/index.html > x ; mv x $(AR)/testnotes3/index.html
 	tidy -config config_tidy.txt $(AR)/testnotes3/one.html > x ; mv x $(AR)/testnotes3/one.html
 	tidy -config config_tidy.txt $(AR)/testnotes3/two.html > x ; mv x $(AR)/testnotes3/two.html
 	tidy -config config_tidy.txt $(AR)/testnotes3/three.html > x ; mv x $(AR)/testnotes3/three.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  -r  $(AR)/testnotes3 $(ER)/testnotes3; \
-		else echo "==deferring: \` diff  -r  $(AR)/testnotes3 $(ER)/testnotes3 \`"; fi
+	bash -c $(call DIFFFUNC,$(S4DR),$(AR)/testnotes3,$(ER)/testnotes3)
 
 	$(SAXON) test24.xml ../html/html.xsl $(SAXONOPT) | tidy -config config_tidy.txt - > $(AR)/test24.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test24.html $(ER)/test24.html; \
-		else echo "==deferring: \` diff  $(AR)/test24.html $(ER)/test24.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test24.html,$(ER)/test24.html)
+
 	$(SAXON) test25.xml ../html/html.xsl $(SAXONOPT) | tidy -config config_tidy.txt - > $(AR)/test25.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test25.html $(ER)/test25.html; \
-		else echo "==deferring: \` diff  $(AR)/test25.html $(ER)/test25.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test25.html,$(ER)/test25.html)
+
 	$(SAXON) test27.xml ../html/html.xsl $(SAXONOPT) cssFile=../tei.css cssSecondaryFile=../css/msdescription.css  | tidy -config config_tidy.txt - > $(AR)/test27.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test27.html $(ER)/test27.html; \
-		else echo "==deferring: \` diff  $(AR)/test27.html $(ER)/test27.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test27.html,$(ER)/test27.html)
 
 	$(SAXON) test28.xml ../html/html.xsl splitLevel=0  STDOUT=false $(SAXONOPT)
 	tidy -config config_tidy.txt index.html > $(AR)/test28.html ; rm index.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test28.html $(ER)/test28.html; \
-		else echo "==deferring: \` diff  $(AR)/test28.html $(ER)/test28.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test28.html,$(ER)/test28.html)
 
 	$(SAXON) test31.xml ../html/html.xsl cssFile="" cssInlineFiles=../tei.css $(SAXONOPT)  | tidy -config config_tidy.txt - > $(AR)/test31.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test31.html $(ER)/test31.html; \
-		else echo "==deferring: \` diff  $(AR)/test31.html $(ER)/test31.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test31.html,$(ER)/test31.html)
 
 	$(SAXON) test32.xml ../html/html.xsl cssFile="" cssInlineFiles=../tei.css $(SAXONOPT)  | tidy -config config_tidy.txt - > $(AR)/test32.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test32.html $(ER)/test32.html; \
-		else echo "==deferring: \` diff  $(AR)/test32.html $(ER)/test32.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test32.html,$(ER)/test32.html)
 
 test-from-html: actual
 	@echo "--------- Test/Makefile target=$@"
 	$(SAXON) test38.htm ../html/html2tei.xsl $(SAXONOPT)  | xmllint --format - > $(AR)/test38.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test38.xml $(ER)/test38.xml; \
-		else echo "==deferring: \` diff  $(AR)/test38.xml $(ER)/test38.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test38.xml,$(ER)/test38.xml)
 
 test-markdown: actual
 	@echo "--------- Test/Makefile target=$@"
 
 	@echo BUILD: markdown to tei
 	$(BINDIR)/markdowntotei $(FLAGS) mdtest1.md $(AR)/mdtest1.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/mdtest1.xml $(ER)/mdtest1.xml; \
-		else echo "==deferring: \` diff  $(AR)/mdtest1.xml $(ER)/mdtest1.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/mdtest1.xml,$(ER)/mdtest1.xml)
 
 	@echo BUILD: tei to markdown
 	$(BINDIR)/teitomarkdown $(FLAGS) test.xml $(AR)/mdtest2.md
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/mdtest2.md $(ER)/mdtest2.md; \
-		else echo "==deferring: \` diff  $(AR)/mdtest2.md $(ER)/mdtest2.md \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/mdtest2.md,$(ER)/mdtest2.md)
 
 test-cocoa: actual
 	@echo "--------- Test/Makefile target=$@"
 	$(BINDIR)/cocoatotei $(FLAGS) cocoatest.txt $(AR)/cocoatest.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/cocoatest.xml $(ER)/cocoatest.xml; \
-		else echo "==deferring: \` diff  $(AR)/cocoatest.xml $(ER)/cocoatest.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/cocoatest.xml,$(ER)/cocoatest.xml)
+
 	$(BINDIR)/cocoatotei $(FLAGS) cocoatest2.txt $(AR)/cocoatest2.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/cocoatest2.xml $(ER)/cocoatest2.xml; \
-		else echo "==deferring: \` diff  $(AR)/cocoatest2.xml $(ER)/cocoatest2.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/cocoatest2.xml,$(ER)/cocoatest2.xml)
 
 test-p4top5: actual
 	@echo "--------- Test/Makefile target=$@"
 	$(SAXON) -o:$(AR)/test17.tei test17.xml ../profiles/default/p4/from.xsl
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test17.tei $(ER)/test17.tei; \
-		else echo "==deferring: \` diff  $(AR)/test17.tei $(ER)/test17.tei \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test17.tei,$(ER)/test17.tei)
+
 	$(SAXON) A54031.tcp ../tcp/tcp2tei.xsl | xmllint --format - > $(AR)/A54031.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/A54031.xml $(ER)/A54031.xml; \
-		else echo "==deferring: \` diff  $(AR)/A54031.xml $(ER)/A54031.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/A54031.xml,$(ER)/A54031.xml)
 
 testsplit:
 	@echo "--------- Test/Makefile target=$@"
@@ -323,79 +262,57 @@ testsplit:
 test-latex: actual
 	@echo "--------- Test/Makefile target=$@"
 	$(SAXON) -o:$(AR)/test.tex test.xml ../latex/latex.xsl  $(SAXONOPT)
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.tex $(ER)/test.tex; \
-		else echo "==deferring: \` diff  $(AR)/test.tex $(ER)/test.tex \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.tex,$(ER)/test.tex)
+
 	$(SAXON) -o:$(AR)/testnotes1.tex testnotes1.xml ../latex/latex.xsl  $(SAXONOPT)
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/testnotes1.tex $(ER)/testnotes1.tex; \
-		else echo "==deferring: \` diff  $(AR)/testnotes1.tex $(ER)/testnotes1.tex \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/testnotes1.tex,$(ER)/testnotes1.tex)
+
 	$(SAXON) -o:$(AR)/test5.tex test5.xml ../latex/latex.xsl  $(SAXONOPT)
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test5.tex $(ER)/test5.tex; \
-		else echo "==deferring: \` diff  $(AR)/test5.tex $(ER)/test5.tex \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test5.tex,$(ER)/test5.tex)
+
 	$(SAXON) -o:$(AR)/test6.tex test6.xml ../slides/teilatex-slides.xsl $(SAXONOPT)
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test6.tex $(ER)/test6.tex; \
-		else echo "==deferring: \` diff  $(AR)/test6.tex $(ER)/test6.tex \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test6.tex,$(ER)/test6.tex)
+
 	$(SAXON) -o:$(AR)/test20.tex test20.xml ../latex/latex.xsl $(SAXONOPT)
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test20.tex $(ER)/test20.tex; \
-		else echo "==deferring: \` diff  $(AR)/test20.tex $(ER)/test20.tex \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test20.tex,$(ER)/test20.tex)
+
 	$(SAXON) -o:$(AR)/test23.tex test23.xml ../latex/latex.xsl $(SAXONOPT)
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test23.tex $(ER)/test23.tex; \
-		else echo "==deferring: \` diff  $(AR)/test23.tex $(ER)/test23.tex \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test23.tex,$(ER)/test23.tex)
+
 	$(SAXON) -o:$(AR)/test24.tex test24.xml ../latex/latex.xsl $(SAXONOPT)
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test24.tex $(ER)/test24.tex; \
-		else echo "==deferring: \` diff  $(AR)/test24.tex $(ER)/test24.tex \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test24.tex,$(ER)/test24.tex)
+
 	$(SAXON) -o:$(AR)/test25.tex test25.xml ../latex/latex.xsl $(SAXONOPT)
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test25.tex $(ER)/test25.tex; \
-		else echo "==deferring: \` diff  $(AR)/test25.tex $(ER)/test25.tex \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test25.tex,$(ER)/test25.tex)
+
 	$(SAXON) -o:$(AR)/test27.tex test27.xml ../latex/latex.xsl $(SAXONOPT)
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test27.tex $(ER)/test27.tex; \
-		else echo "==deferring: \` diff  $(AR)/test27.tex $(ER)/test27.tex \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test27.tex,$(ER)/test27.tex)
 
 test-fo: actual
 	@echo "--------- Test/Makefile target=$@"
 	$(SAXON) -o:$(AR)/test.fo test.xml ../fo/fo.xsl  $(SAXONOPT)
 	$(JING) fo.xsd $(AR)/test.fo
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.fo $(ER)/test.fo; \
-		else echo "==deferring: \` diff  $(AR)/test.fo $(ER)/test.fo \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.fo,$(ER)/test.fo)
 
 	$(SAXON)  test5.xml ../fo/fo.xsl  $(SAXONOPT)  | xmllint --format - > $(AR)/test5.fo
 	$(JING) fo.xsd $(AR)/test5.fo
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test5.fo $(ER)/test5.fo; \
-		else echo "==deferring: \` diff  $(AR)/test5.fo $(ER)/test5.fo \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test5.fo,$(ER)/test5.fo)
 
 	$(SAXON) testnotes1.xml ../fo/fo.xsl  $(SAXONOPT)   | xmllint --format - > $(AR)/testnotes1.fo
 	$(JING) fo.xsd $(AR)/testnotes1.fo
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/testnotes1.fo $(ER)/testnotes1.fo; \
-		else echo "==deferring: \` diff  $(AR)/testnotes1.fo $(ER)/testnotes1.fo \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/testnotes1.fo,$(ER)/testnotes1.fo)
 
 	$(SAXON) -o:$(AR)/test24.fo test24.xml ../fo/fo.xsl $(SAXONOPT)
 	$(JING) fo.xsd $(AR)/test24.fo
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test24.fo $(ER)/test24.fo; \
-		else echo "==deferring: \` diff  $(AR)/test24.fo $(ER)/test24.fo \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test24.fo,$(ER)/test24.fo)
 
 	$(SAXON) -o:$(AR)/test25.fo test25.xml ../fo/fo.xsl $(SAXONOPT)
 	$(JING) fo.xsd $(AR)/test25.fo
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test25.fo $(ER)/test25.fo; \
-		else echo "==deferring: \` diff  $(AR)/test25.fo $(ER)/test25.fo \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test25.fo,$(ER)/test25.fo)
 
 	$(SAXON) test27.xml ../fo/fo.xsl $(SAXONOPT) | xmllint --format - > $(AR)/test27.fo
 	$(JING) fo.xsd $(AR)/test27.fo
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test27.fo $(ER)/test27.fo; \
-		else echo "==deferring: \` diff  $(AR)/test27.fo $(ER)/test27.fo \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test27.fo,$(ER)/test27.fo)
 
 test-epub: actual css
 	@echo "--------- Test/Makefile target=$@"
@@ -406,36 +323,30 @@ test-epub: actual css
 	$(JAVAPRE) ../lib/epubcheck3.jar $(AR)/test.epub
 
 	unzip -t $(AR)/test.epub > $(AR)/test.epub.listing
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then bash -c 'diff  <(sort $(AR)/test.epub.listing) <(sort $(ER)/test.epub.listing)'; \
-		else echo "==deferring: \` bash -c 'diff  <(sort $(AR)/test.epub.listing) <(sort $(ER)/test.epub.listing)' \`"; fi
+	if [ $(DIFFEND) -eq 0 ]; \
+		then bash -c 'diff $(SD1) <(sort $(AR)/test.epub.listing) <(sort $(ER)/test.epub.listing)'; \
+		else echo 'echo "diff $(SD1) $(AR)/test.epub.listing $(ER)/test.epub.listing (sorted)"; diff $(SD1) <(sort $(AR)/test.epub.listing) <(sort $(ER)/test.epub.listing)' >> $(DIFFOUT); fi
 
 	$(BINDIR)/teitoepub $(FLAGS) --fileperpage test.xml $(AR)/test-pages.epub
 	unzip -t $(AR)/test-pages.epub > $(AR)/test.epub.listing2
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then bash -c 'diff  <(sort $(AR)/test.epub.listing2) <(sort $(ER)/test.epub.listing2)'; \
-		else echo "==deferring: \` bash -c 'diff  <(sort $(AR)/test.epub.listing2) <(sort $(ER)/test.epub.listing2)' \`"; fi
+	if [ $(DIFFEND) -eq 0 ]; \
+		then bash -c 'diff $(SD1) <(sort $(AR)/test.epub.listing2) <(sort $(ER)/test.epub.listing2)'; \
+		else echo 'echo "diff $(SD1) $(AR)/test.epub.listing2 $(ER)/test.epub.listing2 (sorted)"; diff $(SD1) <(sort $(AR)/test.epub.listing2) <(sort $(ER)/test.epub.listing2)' >> $(DIFFOUT); fi
 
 test-rdf: actual
 	@echo "--------- Test/Makefile target=$@"
 	$(SAXON) -o:$(AR)/test12.rdf test12.xml ../profiles/default/rdf/to.xsl
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test12.rdf $(ER)/test12.rdf; \
-		else echo "==deferring: \` diff  $(AR)/test12.rdf $(ER)/test12.rdf \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test12.rdf,$(ER)/test12.rdf)
 
 test-text: actual
 	@echo "--------- Test/Makefile target=$@"
 	$(BINDIR)/teitotxt $(FLAGS) test14.xml $(AR)/test.text
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.text $(ER)/test.text; \
-		else echo "==deferring: \` diff  $(AR)/test.text $(ER)/test.text \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.text,$(ER)/test.text)
 
 test-xlsx: actual
 	@echo "--------- Test/Makefile target=$@"
 	$(BINDIR)/xlsxtotei $(FLAGS) test.xlsx $(AR)/test.xlsx.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.xlsx.xml $(ER)/test.xlsx.xml; \
-		else echo "==deferring: \` diff  $(AR)/test.xlsx.xml $(ER)/test.xlsx.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.xlsx.xml,$(ER)/test.xlsx.xml)
 
 test-odt:   test.rng
 	@echo "--------- Test/Makefile target=$@"
@@ -444,94 +355,68 @@ test-odt:   test.rng
 
 	$(BINDIR)/teitoodt $(FLAGS) test.xml $(AR)/test.odt
 	unzip -t $(AR)/test.odt | sort > $(AR)/test.odt.listing
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then bash -c 'diff  <(sort $(AR)/test.odt.listing) <(sort $(ER)/test.odt.listing)'; \
-		else echo "==deferring: \` bash -c 'diff  <(sort $(AR)/test.odt.listing) <(sort $(ER)/test.odt.listing)' \`"; fi
+	if [ $(DIFFEND) -eq 0 ]; \
+		then bash -c 'diff $(SD1) <(sort $(AR)/test.odt.listing) <(sort $(ER)/test.odt.listing)'; \
+		else echo 'echo "diff $(SD1) $(AR)/test.odt.listing $(ER)/test.odt.listing (sorted)"; diff $(SD1) <(sort $(AR)/test.odt.listing) <(sort $(ER)/test.odt.listing)' >> $(DIFFOUT); fi
 
 	unzip -o -q $(AR)/test.odt content.xml
 	xmllint --format content.xml > $(AR)/test.odt_content.xml
 	rm content.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.odt_content.xml $(ER)/test.odt_content.xml; \
-		else echo "==deferring: \` diff  $(AR)/test.odt_content.xml $(ER)/test.odt_content.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.odt_content.xml,$(ER)/test.odt_content.xml)
 
 	$(BINDIR)/odttotei $(FLAGS) test7.odt $(AR)/test7.xml
 	$(JING) $(AR)/test.rng $(AR)/test7.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test7.xml $(ER)/test7.xml; \
-		else echo "==deferring: \` diff  $(AR)/test7.xml $(ER)/test7.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test7.xml,$(ER)/test7.xml)
 
 test-from-docx: test.rng
 	@echo "--------- Test/Makefile target=$@"
 	$(BINDIR)/docxtotei $(FLAGS) test-indexes.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > $(AR)/test-indexes.xml  && rm temp.xml
 	$(JING) $(AR)/test.rng $(AR)/test-indexes.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test-indexes.xml $(ER)/test-indexes.xml; \
-		else echo "==deferring: \` diff  $(AR)/test-indexes.xml $(ER)/test-indexes.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-indexes.xml,$(ER)/test-indexes.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) test11.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl> $(AR)/test11.xml  && rm temp.xml
 	$(JING) $(AR)/test.rng $(AR)/test11.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test11.xml $(ER)/test11.xml; \
-		else echo "==deferring: \` diff  $(AR)/test11.xml $(ER)/test11.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test11.xml,$(ER)/test11.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) --profile=sciencejournal test11.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl> $(AR)/test11a.xml  && rm temp.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test11a.xml $(ER)/test11a.xml; \
-		else echo "==deferring: \` diff  $(AR)/test11a.xml $(ER)/test11a.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test11a.xml,$(ER)/test11a.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) test19.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > $(AR)/test19.xml  && rm temp.xml
 	$(JING) $(AR)/test.rng $(AR)/test19.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test19.xml $(ER)/test19.xml; \
-		else echo "==deferring: \` diff  $(AR)/test19.xml $(ER)/test19.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test19.xml,$(ER)/test19.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) test18.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > $(AR)/test18.xml  && rm temp.xml
 	$(JING) $(AR)/test.rng $(AR)/test18.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test18.xml $(ER)/test18.xml; \
-		else echo "==deferring: \` diff  $(AR)/test18.xml $(ER)/test18.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test18.xml,$(ER)/test18.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) test39.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > $(AR)/test39.xml  && rm temp.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test39.xml $(ER)/test39.xml; \
-		else echo "==deferring: \` diff  $(AR)/test39.xml $(ER)/test39.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test39.xml,$(ER)/test39.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) hyperlinktest.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > $(AR)/hyperlinktest.xml  && rm temp.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/hyperlinktest.xml $(ER)/hyperlinktest.xml; \
-		else echo "==deferring: \` diff  $(AR)/hyperlinktest.xml $(ER)/hyperlinktest.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/hyperlinktest.xml,$(ER)/hyperlinktest.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) --profile=transcription test-rtf2tei.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > $(AR)/test-rtf2tei.xml  && rm temp.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test-rtf2tei.xml $(ER)/test-rtf2tei.xml; \
-		else echo "==deferring: \` diff  $(AR)/test-rtf2tei.xml $(ER)/test-rtf2tei.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-rtf2tei.xml,$(ER)/test-rtf2tei.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) --profile=transcription test29.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > $(AR)/test29.xml  && rm temp.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test29.xml $(ER)/test29.xml; \
-		else echo "==deferring: \` diff  $(AR)/test29.xml $(ER)/test29.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test29.xml,$(ER)/test29.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) --profile=tei test37.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > $(AR)/test37.xml  && rm temp.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test37.xml $(ER)/test37.xml; \
-		else echo "==deferring: \` diff  $(AR)/test37.xml $(ER)/test37.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test37.xml,$(ER)/test37.xml)
 
 	$(BINDIR)/docxtotei $(FLAGS) --profile=tei test40.docx temp.xml
 	xmllint --format temp.xml | perl cleanup.pl > $(AR)/test40.xml  && rm temp.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test40.xml $(ER)/test40.xml; \
-		else echo "==deferring: \` diff  $(AR)/test40.xml $(ER)/test40.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test40.xml,$(ER)/test40.xml)
 
 test-to-docx:
 	@echo "--------- Test/Makefile target=$@"
@@ -539,24 +424,16 @@ test-to-docx:
 	$(BINDIR)/teitodocx $(FLAGS) test.xml
 	unzip -p test.docx word/document.xml | xmllint --format - > $(AR)/test.docx_document.xml
 	unzip -p test.docx docProps/core.xml | xmllint --format - | sed 's/>20.*Z</>20Z</' > $(AR)/test.docx_core.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.docx_document.xml $(ER)/test.docx_document.xml; \
-		else echo "==deferring: \` diff  $(AR)/test.docx_document.xml $(ER)/test.docx_document.xml \`"; fi
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.docx_core.xml $(ER)/test.docx_core.xml; \
-		else echo "==deferring: \` diff  $(AR)/test.docx_core.xml $(ER)/test.docx_core.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.docx_document.xml,$(ER)/test.docx_document.xml)
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.docx_core.xml,$(ER)/test.docx_core.xml)
 
 	$(BINDIR)/teitodocx $(FLAGS) test6.xml
 	unzip -p test6.docx word/document.xml | xmllint --format - > $(AR)/test6.docx_document.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test6.docx_document.xml $(ER)/test6.docx_document.xml; \
-		else echo "==deferring: \` diff  $(AR)/test6.docx_document.xml $(ER)/test6.docx_document.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test6.docx_document.xml,$(ER)/test6.docx_document.xml)
 
 	$(BINDIR)/teitodocx $(FLAGS) testnotes1.xml
 	unzip -p testnotes1.docx word/document.xml | xmllint --format - > $(AR)/testnotes1.docx_document.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/testnotes1.docx_document.xml $(ER)/testnotes1.docx_document.xml; \
-		else echo "==deferring: \` diff  $(AR)/testnotes1.docx_document.xml $(ER)/testnotes1.docx_document.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/testnotes1.docx_document.xml,$(ER)/testnotes1.docx_document.xml)
 
 	$(SAXON) testoucscourses.xml ../profiles/default/p4/from.xsl > $(AR)/testoucscoursesp5.xml
 	$(BINDIR)/teitodocx $(FLAGS) --profile=oucscourses $(AR)/testoucscoursesp5.xml $(AR)/testoucscourses.docx
@@ -566,41 +443,29 @@ test-oddity: actual css
 
 	$(BINDIR)/teitohtml5 $(FLAGS) --summaryDoc --odd test.odd $(AR)/test.odd.html
 	tidy -config config_tidy.txt $(AR)/test.odd.html | perl cleanup.pl> test.temp ; mv test.temp $(AR)/test.odd.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.odd.html $(ER)/test.odd.html; \
-		else echo "==deferring: \` diff  $(AR)/test.odd.html $(ER)/test.odd.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.odd.html,$(ER)/test.odd.html)
 
 	$(BINDIR)/teitoodd $(FLAGS) test.odd $(AR)/test.processedodd
 	$(SAXON) $(AR)/test.processedodd ../odds/extract-isosch.xsl lang=en > $(AR)/test.isosch
 	perl -i -p -e 's/This file generated [0-9T:Z-]+ by .extract-isosch.xsl./DELETED TIMESTAMP/' $(AR)/test.isosch
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test.isosch $(ER)/test.isosch; \
-		else echo "==deferring: \` diff  $(AR)/test.isosch $(ER)/test.isosch \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test.isosch,$(ER)/test.isosch)
 
 	$(BINDIR)/teitornc $(FLAGS) test21.odd $(AR)/test21.odd.rnc
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/test21.odd.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/test21.odd.rnc
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff -bBw $(AR)/test21.odd.rnc $(ER)/test21.odd.rnc; \
-		else echo "==deferring: \` diff -bBw $(AR)/test21.odd.rnc $(ER)/test21.odd.rnc \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test21.odd.rnc,$(ER)/test21.odd.rnc)
 
 	$(BINDIR)/teitornc  $(FLAGS) test15.odd $(AR)/test15.odd.rnc
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/test15.odd.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/test15.odd.rnc
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff -bBw $(AR)/test15.odd.rnc $(ER)/test15.odd.rnc; \
-		else echo "==deferring: \` diff -bBw $(AR)/test15.odd.rnc $(ER)/test15.odd.rnc \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test15.odd.rnc,$(ER)/test15.odd.rnc)
 
 	$(BINDIR)/teitohtml5 $(FLAGS) --summaryDoc --lang=es --profile=tei --odd test15.odd $(AR)/test15.odd.html
 	tidy -config config_tidy.txt $(AR)/test15.odd.html | perl cleanup.pl> test.temp ; mv test.temp $(AR)/test15.odd.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test15.odd.html $(ER)/test15.odd.html; \
-		else echo "==deferring: \` diff  $(AR)/test15.odd.html $(ER)/test15.odd.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test15.odd.html,$(ER)/test15.odd.html)
 
 	$(SAXON) -it:main  -xsl:../tools/oddbyexample.xsl corpus=`pwd`/bare | sed 's/<p>Derived from.*/<p\/>/' >  $(AR)/oddbyexample.odd
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/oddbyexample.odd $(ER)/oddbyexample.odd; \
-		else echo "==deferring: \` diff  $(AR)/oddbyexample.odd $(ER)/oddbyexample.odd \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/oddbyexample.odd,$(ER)/oddbyexample.odd)
 	$(BINDIR)/teitoxsd  $(FLAGS) $(AR)/oddbyexample.odd  $(AR)/oddbyexample.xsd
 	$(BINDIR)/teitornc  $(FLAGS) $(AR)/oddbyexample.odd  $(AR)/oddbyexample.rnc
 	$(BINDIR)/teitodtd  $(FLAGS) $(AR)/oddbyexample.odd  $(AR)/oddbyexample.dtd
@@ -615,9 +480,7 @@ test-oddity: actual css
 	perl -p -i -e 's+ xml:base=".*testdrama.odd"++' $(AR)/testdrama.compiled.xml
 	perl -i -pe 'BEGIN{undef $$/;} s/<\?TEIVERSION[^?]+\?>//smg' $(AR)/testdrama.compiled.xml
 	perl -i -pe 's+(schemaSpec.*source=")$(DEFAULTSOURCE)+$$1https://www.tei-c.org/Vault/P5/current/xml/tei/odd/p5subset.xml+' $(AR)/testdrama.compiled.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/testdrama.compiled.xml $(ER)/testdrama.compiled.xml; \
-		else echo "==deferring: \` diff  $(AR)/testdrama.compiled.xml $(ER)/testdrama.compiled.xml \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/testdrama.compiled.xml,$(ER)/testdrama.compiled.xml)
 
 	$(BINDIR)/teitornc $(FLAGS) test30.odd $(AR)/test30.rnc
 	$(BINDIR)/teitodtd $(FLAGS) test30.odd $(AR)/test30.dtd
@@ -627,12 +490,8 @@ test-oddity: actual css
 	perl -i -pe 'BEGIN{undef $$/;} s/<!--\nDTD[^>]*-->\n//smg' $(AR)/test30.dtd
 	$(JING) -c $(AR)/test30.rnc test36.xml
 	xmllint --noout --dtdvalid $(AR)/test30.dtd test36.xml
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff -bBw $(AR)/test30.rnc $(ER)/test30.rnc; \
-		else echo "==deferring: -bBw \` diff  $(AR)/test30.rnc $(ER)/test30.rnc \`"; fi
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test30.dtd $(ER)/test30.dtd; \
-		else echo "==deferring: \` diff  $(AR)/test30.dtd $(ER)/test30.dtd \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test30.rnc,$(ER)/test30.rnc)
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test30.dtd,$(ER)/test30.dtd)
 
 # MDH 2017-01-07: THE FOLLOWING LINES WILL integrate LB's new pure ODD 
 # master test to replace originals, BUT ONLY WHEN THINGS ARE WORKING PROPERLY.
@@ -646,9 +505,9 @@ test-oddity: actual css
 #	perl -p -i -e 's/generated from ODD source .*//' testODD.rnc
 #	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' testODD.rnc
 # diff against expected results.
-#	if [ $(DIFFNOW) -eq 1 ]; \
+#	if [ $(DIFFEND) -eq 0 ]; \
 #		then diff  testODD.dtd $(ER)/testODD.dtd; fi
-#	if [ $(DIFFNOW) -eq 1 ]; \
+#	if [ $(DIFFEND) -eq 0 ]; \
 #		then diff  testODD.rnc $(ER)/testODD.rnc; fi
 # NOTE: THERE SHOULD BE VALIDATION OF AN INSTANCE FILE AGAINST THE DTD HERE.	
 # OLD ORIGINAL CODE STILL BEING USED FOR THE MOMENT.
@@ -659,17 +518,11 @@ test-oddity: actual css
 	perl -i -pe 'BEGIN{undef $$/;} s/<!--\nDTD[^>]*-->\n//smg' $(AR)/test-pure.dtd
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/test-pure.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/test-pure.rnc
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff -bBw $(AR)/test-pure.rnc $(ER)/test-pure.rnc; \
-		else echo "==deferring: \` diff -bBw $(AR)/test-pure.rnc $(ER)/test-pure.rnc \`"; fi
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test-pure.dtd $(ER)/test-pure.dtd; \
-		else echo "==deferring: \` diff  $(AR)/test-pure.dtd $(ER)/test-pure.dtd \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-pure.rnc,$(ER)/test-pure.rnc)
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-pure.dtd,$(ER)/test-pure.dtd)
 	$(BINDIR)/teitohtml $(FLAGS) --odd test-pure.odd $(AR)/test-pure.odd.html
 	tidy -config config_tidy.txt $(AR)/test-pure.odd.html | perl cleanup.pl> test.temp ; mv test.temp $(AR)/test-pure.odd.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test-pure.odd.html $(ER)/test-pure.odd.html; \
-		else echo "==deferring: \` diff  $(AR)/test-pure.odd.html $(ER)/test-pure.odd.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-pure.odd.html,$(ER)/test-pure.odd.html)
 
 	$(BINDIR)/teitodtd $(FLAGS) test-pure2.odd $(AR)/test-pure2.dtd
 	$(BINDIR)/teitornc $(FLAGS) test-pure2.odd $(AR)/test-pure2.rnc
@@ -680,15 +533,9 @@ test-oddity: actual css
 	perl -i -pe 'BEGIN{undef $$/;} s/<!--\nDTD[^>]*-->\n//smg' $(AR)/test-pure2.dtd
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/test-pure2.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/test-pure2.rnc
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff -bBw $(AR)/test-pure2.rnc $(ER)/test-pure2.rnc; \
-		else echo "==deferring: \` diff -bBw $(AR)/test-pure2.rnc $(ER)/test-pure2.rnc \`"; fi
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test-pure2.dtd $(ER)/test-pure2.dtd; \
-		else echo "==deferring: \` diff  $(AR)/test-pure2.dtd $(ER)/test-pure2.dtd \`"; fi
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test-pure2.odd.html $(ER)/test-pure2.odd.html; \
-		else echo "==deferring: \` diff  $(AR)/test-pure2.odd.html $(ER)/test-pure2.odd.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-pure2.rnc,$(ER)/test-pure2.rnc)
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-pure2.dtd,$(ER)/test-pure2.dtd)
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test-pure2.odd.html,$(ER)/test-pure2.odd.html)
 
 	$(SAXON) test.odd ../odds/odd2odd.xsl > $(AR)/test.odd2odd
 	$(SAXON) $(AR)/test.odd2odd ../odds/odd2dtd.xsl > $(AR)/test.odd2dtd
@@ -718,52 +565,40 @@ test-namespaces: actual
 	$(BINDIR)/teitornc $(FLAGS) test33.odd $(AR)/test33.rnc
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/test33.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/test33.rnc
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff -bBw $(AR)/test33.rnc $(ER)/test33.rnc; \
-		else echo "==deferring: \` diff -bBw $(AR)/test33.rnc $(ER)/test33.rnc \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test33.rnc,$(ER)/test33.rnc)
+
 	$(SAXON) test33.odd ../odds/odd2json.xsl > $(AR)/test33.json
 	perl -p -i -e 's/"date" : "\d+-\d+\-\d+T\d+:\d+:\d+Z",//' $(AR)/test33.json
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test33.json $(ER)/test33.json; \
-		else echo "==deferring: \` diff  $(AR)/test33.json $(ER)/test33.json \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test33.json,$(ER)/test33.json)
 
 	$(BINDIR)/teitornc $(FLAGS) test34.odd $(AR)/test34.rnc
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/test34.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/test34.rnc
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff -bBw $(AR)/test34.rnc $(ER)/test34.rnc; \
-		else echo "==deferring: \` diff -bBw $(AR)/test34.rnc $(ER)/test34.rnc \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test34.rnc,$(ER)/test34.rnc)
+
 	$(SAXON) test34.odd ../odds/odd2json.xsl > $(AR)/test34.json
 	perl -p -i -e 's/"date" : "\d+-\d+\-\d+T\d+:\d+:\d+Z",//' $(AR)/test34.json
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test34.json $(ER)/test34.json; \
-		else echo "==deferring: \` diff  $(AR)/test34.json $(ER)/test34.json \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test34.json,$(ER)/test34.json)
+
 	$(SAXON) test34.odd ../odds/odd2odd.xsl > $(AR)/test34.combined.odd
 	$(SAXON) $(AR)/test34.combined.odd ../odds/odd2json.xsl > $(AR)/test34.combined.json
 	perl -p -i -e 's/"date" : "\d+-\d+\-\d+T\d+:\d+:\d+Z",//' $(AR)/test34.combined.json
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test34.combined.json $(ER)/test34.combined.json; \
-		else echo "==deferring: \` diff  $(AR)/test34.combined.json $(ER)/test34.combined.json \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test34.combined.json,$(ER)/test34.combined.json)
+
 	$(BINDIR)/teitohtml $(FLAGS) --odd --summaryDoc test34.odd $(AR)/test34.odd.html
 	tidy -config config_tidy.txt $(AR)/test34.odd.html | perl cleanup.pl> test.temp ; mv test.temp $(AR)/test34.odd.html
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/test34.odd.html $(ER)/test34.odd.html; \
-		else echo "==deferring: \` diff  $(AR)/test34.odd.html $(ER)/test34.odd.html \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test34.odd.html,$(ER)/test34.odd.html)
 
 	$(BINDIR)/teitornc $(FLAGS) test35.odd $(AR)/test35.rnc
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/test35.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/test35.rnc
-	if [ $(DIFFNOW) -eq 1 ]; \
-	   then diff -bBw $(AR)/test35.rnc $(ER)/test35.rnc; \
-	   else echo "==deferring: \` diff -bBw $(AR)/test35.rnc $(ER)/test35.rnc \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/test35.rnc,$(ER)/test35.rnc)
 
 # HBS 2022-04-30 tests attributes @include and @except
 	$(BINDIR)/teitornc $(FLAGS) testClass.odd $(AR)/testClass.rnc
 	perl -p -i -e 's/generated from ODD source .*//' $(AR)/testClass.rnc
 	perl -i -pe 'BEGIN{undef $$/;} s/# ?Schema[^#]+#[^#]+#[^#]+#[^#]+#\n//smg' $(AR)/testClass.rnc
-	if [ $(DIFFNOW) -eq 1 ]; \
-		then diff  $(AR)/testClass.rnc $(ER)/testClass.rnc; \
-		else echo "==deferring: \` diff -bBw $(AR)/testClass.rnc $(ER)/testClass.rnc \`"; fi
+	bash -c $(call DIFFFUNC,$(S4D1),$(AR)/testClass.rnc,$(ER)/testClass.rnc)
 
 test-scripts:
 	@echo "--------- Test/Makefile target=$@"
@@ -819,3 +654,10 @@ oddtree:
 	@echo "--------- Test/Makefile target=$@"
 	$(SAXON) -s:http://www.tei-c.org/release/xml/tei/odd/p5subset.xml -xsl:../tools/odd-to-tree.xsl -o:oddtree.xml
 	../bin/teitohtml --profile=oxford oddtree.xml oddtree.html
+
+dodiff:
+	@echo "--------- Test/Makefile target=$@"
+	chmod a+x $(DIFFOUT)
+	@if [ $(DIFFEND) -eq 1 ]; then echo " "; echo " "; echo "========= comparisons ========="; fi
+	@if [ $(DIFFEND) -eq 1 ]; then bash -c $(DIFFOUT); fi
+

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -12,7 +12,7 @@
 # aftwer we are done with everything else?
 DIFFEND=0			# 0 = do diff now; 1 = do diffs at end of processing
 
-DIFFSWITCHES=" "		# switches user can pass in to override
+DIFFSWITCHES=" "		# switches user can pass in to # override — not yet implemented
 S4D1=-C0 -bBw			# switches used for most calls to diff
 S4DR=-C0 -bBw -r		# switches used for recursive diff
 


### PR DESCRIPTION
First crack; seems to work, although output is still a bit ugly.

This PR changes only 1 file, Test/Makefile. The default behavior should be pretty much the same, but the DIFFNOW parameter has been ditched in favor of a new DIFFEND parameter, which defaults to 0.

When set to 0, this new parameter causes the Makefile to follow the current default behavior: every time a comparison is required, a `diff` is executed. The entire `make` fails on the first comparison that finds differences.

When set to 1, this new parameter causes the Makefile to build a temporary bash executable file (/tmp/DIFFEM.bash by default) that contains a sequence of all the `diff` commands that _would_ have been executed during the build, and runs it as the last thing the Makefile does. The `make` does not fail on diff errors at all, but they show up in a somewhat reasonable format clumped together at the end.

I have requested review from the three Jenkins maintainers, as side effects in the CI server is the thing I am most worried about.

While this would formally be low priority, I think it is _so_ much easier, I suspect @trishaoconnor would greatly appreciate it if we could have this merged by early December.

Note: The _internal_ documentation in the Makefile itself has been updated, but the [Update P5 Subset](https://docs.google.com/document/d/1UhCg76_AgnS5PW0g_EN6zPZE4tTUs0bNeMXFVmZ4VuQ/edit?tab=t.0#heading=h.7fm4gojxhcp7) document will also need to be updated if & when this PR is merged. (So please either update said documentation or ping me to do so when this is merged.)