### PR TITLE
Fix for issue #789.

### DIFF
--- a/Test/expected-results/test.tex
+++ b/Test/expected-results/test.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setsansfont{Deja Vu Sans}
+  
     \setromanfont{Times New Roman}
   
 \else

--- a/Test/expected-results/test.tex
+++ b/Test/expected-results/test.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setromanfont{Times New Roman}
+  
 \else
   \IfFileExists{utf8x.def}%
    {\usepackage[utf8x]{inputenc}

--- a/Test/expected-results/test20.tex
+++ b/Test/expected-results/test20.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setsansfont{Deja Vu Sans}
+  
     \setromanfont{Times New Roman}
   
 \else

--- a/Test/expected-results/test20.tex
+++ b/Test/expected-results/test20.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setromanfont{Times New Roman}
+  
 \else
   \IfFileExists{utf8x.def}%
    {\usepackage[utf8x]{inputenc}

--- a/Test/expected-results/test23.tex
+++ b/Test/expected-results/test23.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setsansfont{Deja Vu Sans}
+  
     \setromanfont{Times New Roman}
   
 \else

--- a/Test/expected-results/test23.tex
+++ b/Test/expected-results/test23.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setromanfont{Times New Roman}
+  
 \else
   \IfFileExists{utf8x.def}%
    {\usepackage[utf8x]{inputenc}

--- a/Test/expected-results/test24.tex
+++ b/Test/expected-results/test24.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setsansfont{Deja Vu Sans}
+  
     \setromanfont{Times New Roman}
   
 \else

--- a/Test/expected-results/test24.tex
+++ b/Test/expected-results/test24.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setromanfont{Times New Roman}
+  
 \else
   \IfFileExists{utf8x.def}%
    {\usepackage[utf8x]{inputenc}

--- a/Test/expected-results/test25.tex
+++ b/Test/expected-results/test25.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setsansfont{Deja Vu Sans}
+  
     \setromanfont{Times New Roman}
   
 \else

--- a/Test/expected-results/test25.tex
+++ b/Test/expected-results/test25.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setromanfont{Times New Roman}
+  
 \else
   \IfFileExists{utf8x.def}%
    {\usepackage[utf8x]{inputenc}

--- a/Test/expected-results/test27.tex
+++ b/Test/expected-results/test27.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setsansfont{Deja Vu Sans}
+  
     \setromanfont{Times New Roman}
   
 \else

--- a/Test/expected-results/test27.tex
+++ b/Test/expected-results/test27.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setromanfont{Times New Roman}
+  
 \else
   \IfFileExists{utf8x.def}%
    {\usepackage[utf8x]{inputenc}

--- a/Test/expected-results/test5.tex
+++ b/Test/expected-results/test5.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setsansfont{Deja Vu Sans}
+  
     \setromanfont{Times New Roman}
   
 \else

--- a/Test/expected-results/test5.tex
+++ b/Test/expected-results/test5.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setromanfont{Times New Roman}
+  
 \else
   \IfFileExists{utf8x.def}%
    {\usepackage[utf8x]{inputenc}

--- a/Test/expected-results/test6.tex
+++ b/Test/expected-results/test6.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setsansfont{Deja Vu Sans}
+  
     \setromanfont{Times New Roman}
   
 \else

--- a/Test/expected-results/test6.tex
+++ b/Test/expected-results/test6.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setromanfont{Times New Roman}
+  
 \else
   \IfFileExists{utf8x.def}%
    {\usepackage[utf8x]{inputenc}

--- a/Test/expected-results/testnotes1.tex
+++ b/Test/expected-results/testnotes1.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setsansfont{Deja Vu Sans}
+  
     \setromanfont{Times New Roman}
   
 \else

--- a/Test/expected-results/testnotes1.tex
+++ b/Test/expected-results/testnotes1.tex
@@ -17,6 +17,8 @@
   \def\textKorean{\fontspec{Noto Sans CJK KR}}
   \setmonofont{DejaVu Sans Mono}
   
+    \setromanfont{Times New Roman}
+  
 \else
   \IfFileExists{utf8x.def}%
    {\usepackage[utf8x]{inputenc}

--- a/latex/latex_param.xsl
+++ b/latex/latex_param.xsl
@@ -383,7 +383,7 @@ characters. The normal characters remain active for LaTeX commands.
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for literal code</desc>   </doc>
 <xsl:param name="typewriterFont">DejaVu Sans Mono</xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for sans-serif</desc>   </doc>
-<xsl:param name="sansFont"></xsl:param>
+<xsl:param name="sansFont">Deja Vu Sans</xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for serif</desc>   </doc>
 <xsl:param name="romanFont">Times New Roman</xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for gothic</desc>   </doc>

--- a/latex/latex_param.xsl
+++ b/latex/latex_param.xsl
@@ -385,7 +385,7 @@ characters. The normal characters remain active for LaTeX commands.
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for sans-serif</desc>   </doc>
 <xsl:param name="sansFont"></xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for serif</desc>   </doc>
-<xsl:param name="romanFont"></xsl:param>
+<xsl:param name="romanFont">Times New Roman</xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for gothic</desc>   </doc>
 <xsl:param name="gothicFont">Lucida Blackletter</xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for calligraphic</desc>   </doc>

--- a/latex/latex_param.xsl
+++ b/latex/latex_param.xsl
@@ -383,7 +383,7 @@ characters. The normal characters remain active for LaTeX commands.
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for literal code</desc>   </doc>
 <xsl:param name="typewriterFont">DejaVu Sans Mono</xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for sans-serif</desc>   </doc>
-<xsl:param name="sansFont">Deja Vu Sans</xsl:param>
+<xsl:param name="sansFont">DejaVu Sans</xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for serif</desc>   </doc>
 <xsl:param name="romanFont">Times New Roman</xsl:param>
 <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="style" type="string"><desc>Font for gothic</desc>   </doc>


### PR DESCRIPTION
This provides what I think is a useful default value for the romanFont parameter. @sydb Note that there were no errors in Test2, which suggests an area lacking coverage (specifically, Test2 is not doing diff checks of any generated .tex files). 