### PR TITLE
Update gitignore and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,18 @@ lib/fop-*
 *.processedodd
 
 licensekey.txt
+
+# various files and directories that 
+# get temporarily created during 
+# `make test`
+Test/DIFFALL.bash
+Test/actual-results
+*.tmpodd
+Test/Pictures
+Test/media
+Test/charts
+Test/embeddings
+Test/xml.tmp
+Test/test.docx
+Test/test6.docx
+Test/testnotes1.docx

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -648,6 +648,7 @@ clean:
 	(cd ..; for i in css/*; do rm -f `basename $$i`;done)
 	rm -f teitopdf.result.* *~
 	rm -f dcr.tmp xml.tmp
+	rm -f test6.docx test.docx testnotes1.docx
 	rm -fr $(AR)/ charts/ embeddings/ media/ Pictures/
 	rm -f $(DIFFOUT)
 


### PR DESCRIPTION
This PR adds some files to the gitignore list as well as updates the Makefile `clean` target to remove/ignore files which are created during a test run by `make test`. These are all temporary files that should not be added (by accident) to version control and should be cleaned up after testing.