### PR TITLE
Process the new `@key` of `<attRef>`

### DIFF
--- a/common/common_tagdocs.xsl
+++ b/common/common_tagdocs.xsl
@@ -2101,7 +2101,8 @@
         <!-- set a variable that contains all the <attDef> elements from Original that are children of the referenced <classSpec> -->
         <xsl:variable name="theseAttDefs" select="$Original//tei:classSpec[@ident = current-grouping-key()]/tei:attList/tei:attDef" as="element(tei:attDef)*"/>
         <!-- subset of those that have been deleted or over-ridden -->
-        <xsl:variable name="theUnusedAttDefs" select="$theseAttDefs[ not( @ident = current-group()/@name ) ]" as="element(tei:attDef)*"/>
+        <xsl:variable name="theUnusedAttDefs" as="element(tei:attDef)*"
+		      select="$theseAttDefs[ not( @ident = (current-group()/@name, current-group()/@key ) ) ]"/>
        
         <xsl:element namespace="{$outputNS}" name="{$ulName}">
           <xsl:attribute name="{$rendName}" select="'classSpecAttDefs'"/>
@@ -2119,7 +2120,10 @@
             <xsl:element namespace="{$outputNS}" name="{$itemName}">
               <xsl:element namespace="{$outputNS}" name="{$segName}">
                 <xsl:attribute name="{$rendName}">attribute</xsl:attribute>
-                <xsl:sequence select="concat('@', @name )"/>
+                <xsl:sequence select="concat('@', ( @name | @key ) )"/>
+		<!-- Above union works because only 1 of the attrs
+		     @name & @key will ever be present. Should be
+		     reduced to just @key after 2026-11-13 -->
               </xsl:element>
             </xsl:element>
           </xsl:for-each>

--- a/odds/odd2odd.xsl
+++ b/odds/odd2odd.xsl
@@ -92,7 +92,8 @@ of this software, even if advised of the possibility of such damage.
   <xsl:key name="odd2odd-MODULE_MEMBERS_NONELEMENT" match="tei:dataSpec"  use="@module"/>
   <xsl:key name="odd2odd-MODULE_MEMBERS_NONELEMENT" match="tei:macroSpec"  use="@module"/>
   <xsl:key name="odd2odd-MODULE_MEMBERS_NONELEMENT" match="tei:classSpec" use="@module"/>
-  <xsl:key name="odd2odd-ATTREFED" use="substring-before(@name,'.attribute.')" match="tei:attRef"/>
+  <xsl:key name="odd2odd-ATTREFED" use="substring-before( (@name|@key),'.attribute.')" match="tei:attRef"/>
+  <!-- Above union of @name & @key should be reduced to just @key after 2026-11-13 -->
   <xsl:key name="odd2odd-REFED" use="@name" match="rng:ref[ancestor::tei:elementSpec]"/>
   <xsl:key name="odd2odd-REFED" use="@name" match="rng:ref[ancestor::tei:macroSpec and not(@name=ancestor::tei:macroSpec/@ident)]"/>
   <xsl:key name="odd2odd-REFED" use="@name" match="rng:ref[ancestor::tei:datatype]"/>
@@ -1726,8 +1727,7 @@ of this software, even if advised of the possibility of such damage.
                                    ]"/>
     </xsl:if>
     <!-- any direct attRef elements -->
-    <xsl:apply-templates mode="justcopy"
-                         select="tei:attList/tei:attRef"/>
+    <xsl:apply-templates mode="justcopy" select="tei:attList/tei:attRef"/>
     <!-- now look at each of the original object's attributes and see
     if we have an update -->
     <xsl:for-each select="$ORIGINAL/tei:attList">
@@ -1826,10 +1826,9 @@ of this software, even if advised of the possibility of such damage.
       <xsl:choose>
           <xsl:when test="$stripped='true'"/>
           <xsl:when test="$New/tei:equiv">
-            <xsl:apply-templates mode="justcopy"
-                                 select="$New/tei:equiv">
-                <xsl:with-param name="rend">replace</xsl:with-param>
-              </xsl:apply-templates>
+            <xsl:apply-templates mode="justcopy" select="$New/tei:equiv">
+              <xsl:with-param name="rend">replace</xsl:with-param>
+            </xsl:apply-templates>
           </xsl:when>
           <xsl:otherwise>
             <xsl:apply-templates mode="justcopy" select="$Old/tei:equiv"/>
@@ -1837,25 +1836,23 @@ of this software, even if advised of the possibility of such damage.
         </xsl:choose>
         <xsl:choose>
           <xsl:when test="$New/tei:gloss">
-            <xsl:apply-templates mode="justcopy"
-                                 select="$New/tei:gloss">
-                <xsl:with-param name="rend">replace</xsl:with-param>
-              </xsl:apply-templates>
+            <xsl:apply-templates mode="justcopy" select="$New/tei:gloss">
+              <xsl:with-param name="rend">replace</xsl:with-param>
+            </xsl:apply-templates>
           </xsl:when>
           <xsl:otherwise>
-              <xsl:apply-templates mode="justcopy" select="$Old/tei:gloss"/>
+            <xsl:apply-templates mode="justcopy" select="$Old/tei:gloss"/>
           </xsl:otherwise>
         </xsl:choose>
         <xsl:choose>
           <xsl:when test="$stripped='true'"/>
           <xsl:when test="$New/tei:desc">
-            <xsl:apply-templates mode="justcopy"
-                                 select="$New/tei:desc">
-                <xsl:with-param name="rend">replace</xsl:with-param>
-              </xsl:apply-templates>
+            <xsl:apply-templates mode="justcopy" select="$New/tei:desc">
+              <xsl:with-param name="rend">replace</xsl:with-param>
+            </xsl:apply-templates>
           </xsl:when>
           <xsl:otherwise>
-              <xsl:apply-templates mode="justcopy" select="$Old/tei:desc"/>
+            <xsl:apply-templates mode="justcopy" select="$Old/tei:desc"/>
           </xsl:otherwise>
         </xsl:choose>
         <xsl:choose>

--- a/odds/teiodds.xsl
+++ b/odds/teiodds.xsl
@@ -141,6 +141,15 @@ of this software, even if advised of the possibility of such damage.
   <xsl:key match="tei:macroSpec[@predeclare='true']" name="PredeclareAllMacros" use="1"/>
 
 
+  <!--
+      ******** Note for removing deprection on 2026-11-13 or thereafter ********
+      In ~½ dozen places herein you will find the construct “@name |
+      @key”. These unions work because 1 and only 1 of those two
+      attributes will ever be present on the <attRef> being
+      processed. Should be reduced to just @key after 2026-11-13.
+  -->
+
+  
   <xsl:variable name="DEFAULTSOURCE">
     <xsl:choose>
       <xsl:when test="$defaultSource != ''">
@@ -394,14 +403,14 @@ of this software, even if advised of the possibility of such damage.
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template match="tei:attRef" mode="tangle">  
+  <xsl:template match="tei:attRef" mode="tangle">
     <xsl:choose>
       <xsl:when test="key('IDENTS',@class)">
         <rng:ref name="{tei:generateAttRef(.,$generalPrefix)}"/>
       </xsl:when>
       <xsl:when test="@class"/>
       <xsl:otherwise>
-        <rng:ref name="{@name}"/>
+        <rng:ref name="{@name|@key}"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -522,8 +531,7 @@ of this software, even if advised of the possibility of such damage.
                   </xsl:for-each>
                   <xsl:for-each select="tei:attList//tei:attDef[not(@mode='delete')]">
                     <xsl:if test="not(starts-with(@ident,'xmlns'))">
-                      <rng:ref
-                        name="{$c}.attribute.{translate(@ident,':','')}"/>
+                      <rng:ref name="{$c}.attribute.{translate(@ident,':','')}"/>
                     </xsl:if>
                   </xsl:for-each>
                   <xsl:for-each select="tei:attList//tei:attRef">
@@ -533,7 +541,7 @@ of this software, even if advised of the possibility of such damage.
                       </xsl:when>
                       <xsl:when test="@class"/>
                       <xsl:otherwise>
-                        <rng:ref name="{@name}"/>
+			<rng:ref name="{@name|@key}"/>
                       </xsl:otherwise>
                     </xsl:choose>
                   </xsl:for-each>
@@ -2371,11 +2379,11 @@ of this software, even if advised of the possibility of such damage.
         </xsl:choose>
       </xsl:for-each>
       <xsl:choose>
-        <xsl:when test="not(@name)">
+        <xsl:when test="not(@name|@key)">
           <xsl:value-of select="concat(@class,'.attributes')"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:value-of select="concat(@class,'.attribute.',translate(@name,':',''))"/>
+          <xsl:value-of select="concat(@class,'.attribute.',translate( (@name|@key),':',''))"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>


### PR DESCRIPTION
Add processing for new `@key` attribute of `<attRef>` (in addition to, rather than replacing, now deprecated `@name`).

This is intended to address #795, itself intending to address TEIC/TEI#2850.

Passes tests locally (except PDF generation, which _always_ fails locally); P5 (using the "sydb_2850_attRef_key_not_name" branch) builds against this branch.