### PR TITLE
jTEI: split long attribute values inside eg:egXML

### DIFF
--- a/profiles/jtei/jtei.common.xsl
+++ b/profiles/jtei/jtei.common.xsl
@@ -244,7 +244,7 @@
           </seg>
           <seg type="abstract.egXML.attribute.value">
             <xsl:text>="</xsl:text>
-            <xsl:value-of select="local:escapeEntitiesForEgXMLAttribute(.)"/>
+            <xsl:value-of select="replace(., '&amp;([\S])', '&#8203;&amp;$1') ! local:escapeEntitiesForEgXMLAttribute(.)"/>
             <xsl:text>"</xsl:text>
           </seg>
         </xsl:for-each>

--- a/profiles/jtei/jtei.common.xsl
+++ b/profiles/jtei/jtei.common.xsl
@@ -244,7 +244,7 @@
           </seg>
           <seg type="abstract.egXML.attribute.value">
             <xsl:text>="</xsl:text>
-            <xsl:value-of select="replace(., '&amp;([\S])', '&#8203;&amp;$1') ! local:escapeEntitiesForEgXMLAttribute(.)"/>
+            <xsl:value-of select="replace(., '&amp;(\S)', '&#8203;&amp;$1') ! local:escapeEntitiesForEgXMLAttribute(.)"/>
             <xsl:text>"</xsl:text>
           </seg>
         </xsl:for-each>


### PR DESCRIPTION
This PR inserts a zero-width space inside attribute values of elements inside `<egXML>`, before ampersands (`&`) that are _not_ followed by whitespace. 

Motivation: the FOP processor doesn't seem to consider `&` as a line-breaking character, which can cause long URLs in attribute values inside code examples to overflow the page margin. Ampersands that aren't followed by whitespace most likely occur inside URLs, so adding a zero-with space in this limited context should improve wrapping of long URLs.

See this previously merged PR: https://github.com/TEIC/Stylesheets/pull/785.