### PR TITLE
Fix for issue #192: Handle the distinct element in LaTeX processing

### DIFF
--- a/latex/latex_core.xsl
+++ b/latex/latex_core.xsl
@@ -166,7 +166,7 @@ of this software, even if advised of the possibility of such damage.
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
       <desc>Process element emph</desc>
    </doc>
-  <xsl:template match="tei:emph">
+  <xsl:template match="tei:emph | tei:distinct">
       <xsl:text>\textit{</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>}</xsl:text>


### PR DESCRIPTION
To finally close issue #192, this simply adds the `<distinct>` element to the template handling the `<emph>` element; the output is simply italicized text.