### PR TITLE
remove magical xlink namespace binding

### DIFF
--- a/Test/expected-results/test-pure.rnc
+++ b/Test/expected-results/test-pure.rnc
@@ -3,7 +3,6 @@ namespace rng = "http://relaxng.org/ns/structure/1.0"
 namespace sch = "http://purl.oclc.org/dsdl/schematron"
 namespace tei = "http://www.tei-c.org/ns/1.0"
 namespace teix = "http://www.tei-c.org/ns/Examples"
-namespace xlink = "http://www.w3.org/1999/xlink"
 
 stuff =
   

--- a/Test/expected-results/test-pure2.rnc
+++ b/Test/expected-results/test-pure2.rnc
@@ -6,7 +6,6 @@ namespace svg = "http://www.w3.org/2000/svg"
 namespace tei = "http://www.tei-c.org/ns/1.0"
 namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
-namespace xlink = "http://www.w3.org/1999/xlink"
 
 stuffPart = bob | bit
 stuff =

--- a/Test/expected-results/test.rng
+++ b/Test/expected-results/test.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:teix="http://www.tei-c.org/ns/Examples" xmlns:xlink="http://www.w3.org/1999/xlink" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes" ns="http://www.tei-c.org/ns/1.0">
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:teix="http://www.tei-c.org/ns/Examples" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes" ns="http://www.tei-c.org/ns/1.0">
   
   <!---->
   <define name="macro.abContent">

--- a/Test/expected-results/test15.odd.rnc
+++ b/Test/expected-results/test15.odd.rnc
@@ -5,7 +5,6 @@ namespace sch = "http://purl.oclc.org/dsdl/schematron"
 default namespace tei = "http://www.tei-c.org/ns/1.0"
 namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
-namespace xlink = "http://www.w3.org/1999/xlink"
 
 macro.abContent = (text | model.paraPart | ab)*
 macro.paraContent = (text | model.paraPart)*

--- a/Test/expected-results/test21.odd.rnc
+++ b/Test/expected-results/test21.odd.rnc
@@ -5,7 +5,6 @@ namespace sch = "http://purl.oclc.org/dsdl/schematron"
 default namespace tei = "http://www.tei-c.org/ns/1.0"
 namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
-namespace xlink = "http://www.w3.org/1999/xlink"
 
 macro.abContent = (text | model.paraPart | ab)*
 macro.paraContent = (text | model.paraPart)*

--- a/Test/expected-results/test30.rnc
+++ b/Test/expected-results/test30.rnc
@@ -6,7 +6,6 @@ namespace sch = "http://purl.oclc.org/dsdl/schematron"
 default namespace tei = "http://www.tei-c.org/ns/1.0"
 namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
-namespace xlink = "http://www.w3.org/1999/xlink"
 
 Tmacro.abContent = (text | Tmodel.paraPart | Tab)*
 Tmacro.paraContent = (text | Tmodel.paraPart)*

--- a/Test/expected-results/test33.rnc
+++ b/Test/expected-results/test33.rnc
@@ -7,7 +7,6 @@ namespace sch = "http://purl.oclc.org/dsdl/schematron"
 namespace tei = "http://www.tei-c.org/ns/1.0"
 namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
-namespace xlink = "http://www.w3.org/1999/xlink"
 
 tei_macro.abContent = (text | tei_model.paraPart | tei_ab)*
 tei_macro.paraContent = (text | tei_model.paraPart)*

--- a/Test/expected-results/test34.rnc
+++ b/Test/expected-results/test34.rnc
@@ -8,7 +8,6 @@ namespace sch = "http://purl.oclc.org/dsdl/schematron"
 namespace tei = "http://www.tei-c.org/ns/1.0"
 namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
-namespace xlink = "http://www.w3.org/1999/xlink"
 
 tei_macro.abContent = (text | tei_model.paraPart | tei_ab)*
 tei_macro.paraContent = (text | tei_model.paraPart)*

--- a/Test/expected-results/test35.rnc
+++ b/Test/expected-results/test35.rnc
@@ -6,7 +6,6 @@ namespace sch = "http://purl.oclc.org/dsdl/schematron"
 namespace tei = "http://www.tei-c.org/ns/1.0"
 namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
-namespace xlink = "http://www.w3.org/1999/xlink"
 
 
 # This template file is freely available and you are hereby authorised to copy, modify, and redistribute it in any way without further reference or permissions. When making such modifications, you are strongly recommended to change the present text to include an accurate statement of the licencing conditions applicable to your modified text.

--- a/Test/expected-results/testClass.rnc
+++ b/Test/expected-results/testClass.rnc
@@ -5,7 +5,6 @@ namespace sch = "http://purl.oclc.org/dsdl/schematron"
 default namespace tei = "http://www.tei-c.org/ns/1.0"
 namespace teix = "http://www.tei-c.org/ns/Examples"
 namespace xi = "http://www.w3.org/2001/XInclude"
-namespace xlink = "http://www.w3.org/1999/xlink"
 
 macro.paraContent = (text | model.paraPart)*
 att.cmc.attributes = att.cmc.attribute.generatedBy

--- a/Test2/expected-results/testAttValQuant.rng
+++ b/Test2/expected-results/testAttValQuant.rng
@@ -1,7 +1,6 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0"
          xmlns:tei="http://www.tei-c.org/ns/1.0"
          xmlns:teix="http://www.tei-c.org/ns/Examples"
-         xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0">
    <define name="macro.paraContent">

--- a/Test2/expected-results/testNonTeiOdd1.rng
+++ b/Test2/expected-results/testNonTeiOdd1.rng
@@ -1,7 +1,6 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0"
          xmlns:tei="http://www.tei-c.org/ns/1.0"
          xmlns:teix="http://www.tei-c.org/ns/Examples"
-         xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.w3.org/1999/xhtml">
    <define name="macro.paraContent">

--- a/Test2/expected-results/testPure1.rng
+++ b/Test2/expected-results/testPure1.rng
@@ -1,7 +1,6 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0"
          xmlns:tei="http://www.tei-c.org/ns/1.0"
          xmlns:teix="http://www.tei-c.org/ns/Examples"
-         xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0">
    <define name="t_macro.paraContent">

--- a/odds/odd2relax.xsl
+++ b/odds/odd2relax.xsl
@@ -139,7 +139,6 @@ of this software, even if advised of the possibility of such damage.
       <xsl:with-param name="body">
         <grammar xmlns="http://relaxng.org/ns/structure/1.0"
           xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-          xmlns:xlink="http://www.w3.org/1999/xlink"
           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
           <xsl:attribute name="ns">
             <xsl:choose>


### PR DESCRIPTION
Fixing #800 by removing the magic binding of the prefix "xlink:" to the namespace http://www.w3.org/1999/xlink; updated expected results to match.

The remaining question is what do we do, if anything, to warn users about this? Is this behavior documented anywhere?